### PR TITLE
DP-91 Add logging aspect; Add string holder for confidential data

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/application/logging/LoggingAspect.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.clicktravel.cheddar.server.application.logging;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+//@formatter:off
+/**
+ * Aspect for automatically logging method calls. The methods to log are identified by a {@code @Pointcut} definition.
+ * A log message at DEBUG level is written when the logged method completes. The message includes class and name of
+ * method, call parameters, returned value (or exception) and method execution time.</br>
+ * To use this class, define a derived class as follows:
+ * <pre>
+ * {@code @Aspect}
+ * {@code @Order(50)}
+ * {@code @Component}
+ * public class MyLoggingAspect extends LoggingAspect
+ *     {@code @Override}
+ *     {@code @Pointcut("myPointcut")}
+ *     public void loggable() {}
+ * }
+ * </pre>
+ */
+//@formatter:on
+public abstract class LoggingAspect {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public abstract void loggable();
+
+    @Around("loggable()")
+    protected Object advice(final ProceedingJoinPoint point) throws Throwable {
+        // If not logging, avoid overhead of building expressions in logging statements
+        return logger.isDebugEnabled() ? proceedAndLog(point) : point.proceed();
+    }
+
+    private Object proceedAndLog(final ProceedingJoinPoint point) throws Throwable {
+        final String methodCallDetail = methodCallDetail(point);
+        final long startTime = System.currentTimeMillis();
+        try {
+            final Object result = point.proceed();
+            logger.debug("Method call; call:[{}] return:[{}] timeMillis:[{}]", methodCallDetail, result,
+                    System.currentTimeMillis() - startTime);
+            return result;
+        } catch (final Throwable e) {
+            logger.debug("Method call; call:[{}] exception:[{}] timeMillis:[{}]", methodCallDetail, e,
+                    System.currentTimeMillis() - startTime);
+            throw e;
+        }
+    }
+
+    private String methodCallDetail(final ProceedingJoinPoint point) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(point.getTarget().getClass().getSimpleName());
+        sb.append('.');
+        sb.append(((MethodSignature) (point.getSignature())).getMethod().getName());
+        sb.append('(');
+        boolean firstArg = true;
+        for (final Object arg : point.getArgs()) {
+            if (!firstArg) {
+                sb.append(',');
+            }
+            firstArg = false;
+            sb.append(arg == null ? "null" : arg.toString());
+        }
+        sb.append(')');
+        return sb.toString();
+    }
+}

--- a/commons/commons-lang/src/main/java/com/clicktravel/common/security/ConfidentialString.java
+++ b/commons/commons-lang/src/main/java/com/clicktravel/common/security/ConfidentialString.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.clicktravel.common.security;
+
+/**
+ * Holds a {@link String} that has confidential information which should not be casually displayed. {@link #toString()}
+ * is defined to not include the confidential information.
+ */
+public class ConfidentialString {
+
+    private final String string;
+
+    public ConfidentialString() {
+        this(null);
+    }
+
+    public ConfidentialString(final String string) {
+        this.string = string;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    @Override
+    public String toString() {
+        return "** CONFIDENTIAL **";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((string == null) ? 0 : string.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ConfidentialString other = (ConfidentialString) obj;
+        if (string == null) {
+            if (other.string != null) {
+                return false;
+            }
+        } else if (!string.equals(other.string)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/commons/commons-lang/src/main/java/com/clicktravel/common/security/ConfidentialString.java
+++ b/commons/commons-lang/src/main/java/com/clicktravel/common/security/ConfidentialString.java
@@ -24,10 +24,6 @@ public class ConfidentialString {
 
     private final String string;
 
-    public ConfidentialString() {
-        this(null);
-    }
-
     public ConfidentialString(final String string) {
         this.string = string;
     }

--- a/commons/commons-lang/src/test/java/com/clicktravel/common/security/ConfidentialStringTest.java
+++ b/commons/commons-lang/src/test/java/com/clicktravel/common/security/ConfidentialStringTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.clicktravel.common.security;
+
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class ConfidentialStringTest {
+
+    @Test
+    public void shouldReturnNull_onNoArgConstructor() {
+        // When
+        final ConfidentialString s = new ConfidentialString();
+
+        // Then
+        assertNotNull(s);
+        assertNull(s.getString());
+    }
+
+    @Test
+    public void shouldReturnNull_onConstructorWithNullStringArg() {
+        // Given
+        final String string = null;
+
+        // When
+        final ConfidentialString s = new ConfidentialString(string);
+
+        // Then
+        assertNotNull(s);
+        assertNull(s.getString());
+    }
+
+    @Test
+    public void shouldReturnString_onConstructorWithStringArg() {
+        // Given
+        final String string = randomString();
+
+        // When
+        final ConfidentialString s = new ConfidentialString(string);
+
+        // Then
+        assertNotNull(s);
+        assertEquals(string, s.getString());
+    }
+
+    @Test
+    public void shouldNotContainStringContents_onToString() {
+        // Given
+        final String string = randomString();
+        final ConfidentialString s = new ConfidentialString(string);
+
+        // When
+        final String toString = s.toString();
+
+        // Then
+        assertFalse(toString.contains(string));
+    }
+
+    @Test
+    public void shouldBeEqual_withSameStringContent() {
+        // Given
+        final String string1 = randomString();
+        final String string2 = new String(string1); // new string with same content
+        final ConfidentialString s1 = new ConfidentialString(string1);
+        final ConfidentialString s2 = new ConfidentialString(string2);
+
+        // When
+        final boolean isEquals = s1.equals(s2);
+
+        // Then
+        assertTrue("ConfidentialStrings with same content should be equal", isEquals);
+    }
+
+    @Test
+    public void shouldHaveEqualHash_withSameStringContent() {
+        // Given
+        final String string1 = randomString();
+        final String string2 = new String(string1); // new string with same content
+        final int s1HashCode = new ConfidentialString(string1).hashCode();
+        final int s2HashCode = new ConfidentialString(string2).hashCode();
+
+        // When
+        final boolean isHashEquals = s1HashCode == s2HashCode;
+
+        // Then
+        assertTrue("ConfidentialStrings with same content should have equal hashCode", isHashEquals);
+    }
+
+    @Test
+    public void shouldNotBeEqual_withDifferentStringContent() {
+        // Given
+        final String string1 = randomString();
+        final String string2 = randomString(1 + string1.length()); // different length to string1
+        final ConfidentialString s1 = new ConfidentialString(string1);
+        final ConfidentialString s2 = new ConfidentialString(string2);
+
+        // When
+        final boolean isEquals = s1.equals(s2);
+
+        // Then
+        assertFalse("ConfidentialStrings with different content should not be equal", isEquals);
+    }
+
+}

--- a/commons/commons-lang/src/test/java/com/clicktravel/common/security/ConfidentialStringTest.java
+++ b/commons/commons-lang/src/test/java/com/clicktravel/common/security/ConfidentialStringTest.java
@@ -24,16 +24,6 @@ import org.junit.Test;
 public class ConfidentialStringTest {
 
     @Test
-    public void shouldReturnNull_onNoArgConstructor() {
-        // When
-        final ConfidentialString s = new ConfidentialString();
-
-        // Then
-        assertNotNull(s);
-        assertNull(s.getString());
-    }
-
-    @Test
     public void shouldReturnNull_onConstructorWithNullStringArg() {
         // Given
         final String string = null;


### PR DESCRIPTION
Enable automatic logging against a pointcut. This is intended for uniform logging against all application API methods (command and query services) but could also be used for other layers.
Because potential confidential information is passed via the API, a simple string holder is also added, which does not display the string content in its toString() method. This is intended to hold strings passed to API methods like passwords and credit card numbers.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>