### PR TITLE
FC-86 Hash generation should be platform independent

### DIFF
--- a/commons/commons-lang/src/main/java/com/clicktravel/common/hash/HashUtils.java
+++ b/commons/commons-lang/src/main/java/com/clicktravel/common/hash/HashUtils.java
@@ -16,6 +16,7 @@
  */
 package com.clicktravel.common.hash;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -61,7 +62,7 @@ public class HashUtils {
     private static String generateHash(final String input, final HashType hashType) {
         try {
             final MessageDigest md = MessageDigest.getInstance(hashType.value());
-            md.update(input.getBytes());
+            md.update(input.getBytes(StandardCharsets.UTF_8));
             final byte byteData[] = md.digest();
             final StringBuilder sb = new StringBuilder();
             for (final byte element : byteData) {


### PR DESCRIPTION
Do not depend on the default platform setting for character encoding when generating hashes.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>