### PR TITLE
Added custom naming strategy to allow cloud search document to have camel case property names

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/DocumentPropertyNamingStrategy.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/DocumentPropertyNamingStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package com.clicktravel.infrastructure.persistence.aws.cloudsearch.client;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
+
+/**
+ * A property naming strategy used by Object Mapper to correctly parse the JSON returned by Cloud Search into document
+ * objects due to the lack of support for camel case. Only lower case index names are currently supported.
+ * 
+ * @see com.fasterxml.jackson.databind.ObjectMapper#setPropertyNamingStrategy(PropertyNamingStrategy)
+ * 
+ * @author james b
+ */
+
+public class DocumentPropertyNamingStrategy extends PropertyNamingStrategy {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public String nameForField(final MapperConfig<?> config, final AnnotatedField field, final String defaultName) {
+        return reformatFeildName(defaultName);
+
+    }
+
+    @Override
+    public String nameForGetterMethod(final MapperConfig<?> config, final AnnotatedMethod method,
+            final String defaultName) {
+        return reformatFeildName(defaultName);
+    }
+
+    @Override
+    public String nameForSetterMethod(final MapperConfig<?> config, final AnnotatedMethod method,
+            final String defaultName) {
+        return reformatFeildName(defaultName);
+    }
+
+    private String reformatFeildName(final String defaultFieldName) {
+        return defaultFieldName.toLowerCase();
+    }
+}

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentSearchResponseUnmarshaller.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentSearchResponseUnmarshaller.java
@@ -40,6 +40,7 @@ public class JsonDocumentSearchResponseUnmarshaller {
         mapper.registerModule(module);
         mapper.configure(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED, true);
         mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        mapper.setPropertyNamingStrategy(new DocumentPropertyNamingStrategy());
     }
 
     public <T extends Document> T unmarshall(final Map<String, List<String>> fields, final Class<T> documentClass) {

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentSearchResponseUnmarshaller.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentSearchResponseUnmarshaller.java
@@ -40,7 +40,7 @@ public class JsonDocumentSearchResponseUnmarshaller {
         mapper.registerModule(module);
         mapper.configure(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED, true);
         mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
-        mapper.setPropertyNamingStrategy(new DocumentPropertyNamingStrategy());
+        mapper.setPropertyNamingStrategy(new LowerCasePropertyNamingStrategy());
     }
 
     public <T extends Document> T unmarshall(final Map<String, List<String>> fields, final Class<T> documentClass) {

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentUpdateMarshaller.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentUpdateMarshaller.java
@@ -42,7 +42,7 @@ public class JsonDocumentUpdateMarshaller {
         final SimpleModule jodaDateTimeModule = new SimpleModule();
         jodaDateTimeModule.addSerializer(DateTime.class, new JodaDateTimeSerializer());
         mapper.registerModule(jodaDateTimeModule);
-        mapper.setPropertyNamingStrategy(new DocumentPropertyNamingStrategy());
+        mapper.setPropertyNamingStrategy(new LowerCasePropertyNamingStrategy());
     }
 
     private String marshallDocumentUpdates(final Collection<DocumentUpdate> documentUpdates) {

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentUpdateMarshaller.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentUpdateMarshaller.java
@@ -42,6 +42,7 @@ public class JsonDocumentUpdateMarshaller {
         final SimpleModule jodaDateTimeModule = new SimpleModule();
         jodaDateTimeModule.addSerializer(DateTime.class, new JodaDateTimeSerializer());
         mapper.registerModule(jodaDateTimeModule);
+        mapper.setPropertyNamingStrategy(new DocumentPropertyNamingStrategy());
     }
 
     private String marshallDocumentUpdates(final Collection<DocumentUpdate> documentUpdates) {

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/LowerCasePropertyNamingStrategy.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/LowerCasePropertyNamingStrategy.java
@@ -30,29 +30,29 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
  * @author james b
  */
 
-public class DocumentPropertyNamingStrategy extends PropertyNamingStrategy {
+public class LowerCasePropertyNamingStrategy extends PropertyNamingStrategy {
 
     private static final long serialVersionUID = 1L;
 
     @Override
     public String nameForField(final MapperConfig<?> config, final AnnotatedField field, final String defaultName) {
-        return reformatFeildName(defaultName);
+        return formattedFieldName(defaultName);
 
     }
 
     @Override
     public String nameForGetterMethod(final MapperConfig<?> config, final AnnotatedMethod method,
             final String defaultName) {
-        return reformatFeildName(defaultName);
+        return formattedFieldName(defaultName);
     }
 
     @Override
     public String nameForSetterMethod(final MapperConfig<?> config, final AnnotatedMethod method,
             final String defaultName) {
-        return reformatFeildName(defaultName);
+        return formattedFieldName(defaultName);
     }
 
-    private String reformatFeildName(final String defaultFieldName) {
+    private String formattedFieldName(final String defaultFieldName) {
         return defaultFieldName.toLowerCase();
     }
 }

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/CloudSearchEngineTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/CloudSearchEngineTest.java
@@ -589,7 +589,7 @@ public class CloudSearchEngineTest {
         final Hit hit = new Hit();
         hit.withId(document.getId());
         final Map<String, List<String>> fields = new HashMap<>();
-        fields.put("stringProperty", Arrays.asList(document.getStringProperty()));
+        fields.put("stringproperty", Arrays.asList(document.getStringProperty()));
         hit.withFields(fields);
         hits.withHit(hit);
         hits.withFound(1l);

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentSearchResponseUnmarshallerTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/client/JsonDocumentSearchResponseUnmarshallerTest.java
@@ -52,16 +52,16 @@ public class JsonDocumentSearchResponseUnmarshallerTest {
         // Given
         final Map<String, List<String>> fields = new HashMap<>();
         final String stringProperty = randomString(10);
-        fields.put("stringProperty", Arrays.asList(stringProperty));
+        fields.put("stringproperty", Arrays.asList(stringProperty));
         final String[] stringListValues = new String[3];
         stringListValues[0] = randomString(10);
         stringListValues[1] = randomString(10);
         stringListValues[2] = randomString(10);
-        fields.put("collectionProperty", Arrays.asList(stringListValues[0], stringListValues[1], stringListValues[2]));
+        fields.put("collectionproperty", Arrays.asList(stringListValues[0], stringListValues[1], stringListValues[2]));
         final MyEnum myEnum = randomEnum(MyEnum.class);
-        fields.put("myEnum", Arrays.asList(myEnum.name()));
+        fields.put("myenum", Arrays.asList(myEnum.name()));
         final DateTime dateTimeValue = randomDateTime();
-        fields.put("dateTimeValue", Arrays.asList(ISODateTimeFormat.dateTime().withZoneUTC().print(dateTimeValue)));
+        fields.put("datetimevalue", Arrays.asList(ISODateTimeFormat.dateTime().withZoneUTC().print(dateTimeValue)));
         final JsonDocumentSearchResponseUnmarshaller jsonDocumentSearchResponseUnmarshaller = new JsonDocumentSearchResponseUnmarshaller();
 
         // When


### PR DESCRIPTION
- Added Document property naming strategy to read all index names in lower case before unmarshalling to a document object.
- Set the naming strategy on the JSON document un/marshallers
- Updated tests to fix breakages