### PR TITLE
DP-101 Use Jersey 2.15 and Grizzly 2.3.16

### DIFF
--- a/cheddar/cheddar-rest/build.gradle
+++ b/cheddar/cheddar-rest/build.gradle
@@ -1,6 +1,6 @@
 apply from: '../../test.gradle'
 
-def jerseyVersion = '2.7'
+def jerseyVersion = '2.15'
 
 dependencies {
     compile project(':commons:commons-lang')
@@ -11,6 +11,6 @@ dependencies {
 
     compile "org.glassfish.jersey.core:jersey-server:${jerseyVersion}"
     compile "org.glassfish.jersey.media:jersey-media-moxy:${jerseyVersion}"
-    compile "org.glassfish.jersey.media:jersey-media-multipart:$jerseyVersion"
+    compile "org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}"
     compile 'org.slf4j:slf4j-api:1.7.5'
 }

--- a/cheddar/cheddar-server/build.gradle
+++ b/cheddar/cheddar-server/build.gradle
@@ -1,12 +1,13 @@
 apply from: '../../test.gradle'
 
+def jerseyVersion = '2.15'
+
 dependencies {
     compile project(':cheddar:cheddar-rest')
     compile project(':cheddar:cheddar-messaging')
     compile project(':cheddar:cheddar-system-events')
 
-    compile "org.glassfish.jersey.ext:jersey-spring3:2.7"
-    compile "org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.4"
-    compile "org.glassfish.grizzly:grizzly-http-servlet:2.3.3"
+    compile "org.glassfish.jersey.ext:jersey-spring3:${jerseyVersion}"
+    compile "org.glassfish.jersey.containers:jersey-container-grizzly2-http:${jerseyVersion}"
     compile 'javax.servlet:javax.servlet-api:3.1.0'
 }

--- a/commons/commons-httpclient/build.gradle
+++ b/commons/commons-httpclient/build.gradle
@@ -1,4 +1,4 @@
-def jerseyVersion = '2.7'
+def jerseyVersion = '2.15'
 
 dependencies {
     compile project(':commons:commons-lang')


### PR DESCRIPTION
- Corrected version conflicts on various Jersey artifacts (was a mixture of 2.4 and 2.7) by upgrading to Jersey 2.15 throughout
- Updated to use Grizzly 2.3.16, which is pulled in by Jersey 2.15 Grizzly integration. Updated thread pool configuration, which differs in this newer Grizzly version.

These changes are in preparation to use Jersey Test.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>