### PR TITLE
Allowed FeatureRegistry to be initialised many times with no side-effect

### DIFF
--- a/cheddar/cheddar-domain/src/main/java/com/clicktravel/cheddar/domain/feature/toggle/FeaturePropertyAdapter.java
+++ b/cheddar/cheddar-domain/src/main/java/com/clicktravel/cheddar/domain/feature/toggle/FeaturePropertyAdapter.java
@@ -18,17 +18,16 @@ package com.clicktravel.cheddar.domain.feature.toggle;
 
 /**
  * Adapter to translate from a Feature to an associated Property key.
- * 
+ *
  */
 public interface FeaturePropertyAdapter {
 
     /**
      * Translates a Feature to a property which will be used to look up the value of the Feature toggle.
-     * 
-     * The value of the property will be looked up to determine if the Feature is turned off which is represented by
-     * "true" or off, which is represented by anything other than "true". NOTE: The value of the property is
-     * case-insensitive.
-     * 
+     *
+     * The value of the property will be looked up to determine if the Feature is enabled/disabled. If the value is
+     * "true" (case-insensitive) the feature will be enabled, otherwise the feature disabled.
+     *
      * @param feature The feature for which the property key is to be determined.
      * @return The property key associated with the Feature
      */

--- a/cheddar/cheddar-domain/src/main/java/com/clicktravel/cheddar/domain/feature/toggle/FeatureRegistry.java
+++ b/cheddar/cheddar-domain/src/main/java/com/clicktravel/cheddar/domain/feature/toggle/FeatureRegistry.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * Feature Registry to manage Features and report on their status: on or off.
+ * Feature Registry to manage Features and report on their status: enabled/disabled.
  *
  */
 public class FeatureRegistry {
@@ -67,10 +67,10 @@ public class FeatureRegistry {
     }
 
     /**
-     * Reports the current status (on/off) for the given Feature
+     * Reports the current status (enabled/disabled) for the given Feature
      *
      * @param feature The Feature for which the status is to be reported.
-     * @return The status of the Feature (true = on, false = off)
+     * @return The enabled/disabled status of the Feature (true = enabled, false = disabled)
      */
     public static boolean isEnabled(final Feature feature) {
         if (FEATURES.get(feature) == null) {

--- a/cheddar/cheddar-domain/src/main/java/com/clicktravel/cheddar/domain/feature/toggle/FeatureRegistry.java
+++ b/cheddar/cheddar-domain/src/main/java/com/clicktravel/cheddar/domain/feature/toggle/FeatureRegistry.java
@@ -23,20 +23,19 @@ import java.util.Properties;
 
 /**
  * Feature Registry to manage Features and report on their status: on or off.
- * 
+ *
  */
 public class FeatureRegistry {
 
     private static Properties PROPERTIES = new Properties();
     private static FeaturePropertyAdapter FEATURE_PROPERTY_ADAPTER;
     private static final Map<Feature, Boolean> FEATURES = new HashMap<>();
-    private static boolean initialized;
 
     /**
      * Initialises the FeatureRegistry with a class path location from which to load properties for the feature toggles.
-     * 
+     *
      * The DefaultFeaturePropertyAdapter is used to translate from Feature to property key.
-     * 
+     *
      * @param featureTogglePropertiesLocation The class path location of the properties file from which to read feature
      *            toggle properties
      */
@@ -46,9 +45,9 @@ public class FeatureRegistry {
 
     /**
      * Initialises the FeatureRegistry with a classpath location from which to load properties for the feature toggles.
-     * 
+     *
      * The DefaultFeaturePropertyAdapter is used to translate from Feature to property key.
-     * 
+     *
      * @param featureTogglePropertiesLocation The class path location of the properties file from which to read feature
      *            toggle properties
      * @param featurePropertyAdapter The FeaturePropertyAdapter which is to be used to translate from Feature to
@@ -56,14 +55,11 @@ public class FeatureRegistry {
      */
     public static void init(final String featureTogglePropertiesLocation,
             final FeaturePropertyAdapter featurePropertyAdapter) {
-        if (initialized) {
-            throw new IllegalStateException("Feature Registry already initialized");
-        }
-        initialized = true;
         FEATURE_PROPERTY_ADAPTER = featurePropertyAdapter;
         try {
+            PROPERTIES.clear();
             PROPERTIES
-                    .load(FeatureRegistry.class.getClassLoader().getResourceAsStream(featureTogglePropertiesLocation));
+            .load(FeatureRegistry.class.getClassLoader().getResourceAsStream(featureTogglePropertiesLocation));
         } catch (final IOException e) {
             throw new IllegalStateException("Could not load feature toggle properties from location: "
                     + featureTogglePropertiesLocation, e);
@@ -72,7 +68,7 @@ public class FeatureRegistry {
 
     /**
      * Reports the current status (on/off) for the given Feature
-     * 
+     *
      * @param feature The Feature for which the status is to be reported.
      * @return The status of the Feature (true = on, false = off)
      */


### PR DESCRIPTION
The FeatureRegistry uses a static state so it means that within the JVM it can only be initialised once. This caused a problem with reloading contexts again within the JVM as we need to within the Jersey Tests.