### PR TITLE
Set false to exception thrown when new event attributes are added to events

### DIFF
--- a/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/AbstractEvent.java
+++ b/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/AbstractEvent.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
@@ -30,6 +31,7 @@ public abstract class AbstractEvent implements Event {
 
     static {
         MAPPER.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     @Override


### PR DESCRIPTION
When services that use Cheddar integrate on events the event code is sometimes shared to reduce duplication. When one of these events changes the other must also be built and redeployed because currently a 'UnrecognizedPropertyException' is thrown. The change in settings in this commit to the mapper will stop this behaviour from occurring reducing the coupling between services that integrate on events.