### PR TITLE
DP-95 Added build option to run AWS integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,15 +101,25 @@ task checkstyleAggregate << {
 }
 checkstyleAggregate.dependsOn { subproj.check }
 
+ext.runIntegrationTests = System.properties['runIntegrationTests'] != null
+
 // Execute check on all subprojects
 task checkAll { dependsOn { subproj.check } }
+
+// Execute check on all subprojects and follow with integration tests if needed
+def integrationTestTask = tasks.getByPath(':cheddar:cheddar-integration-aws:integrationTest')
+task checkAllWithIntegrationIfNeeded {
+    dependsOn { checkAll }
+    if (runIntegrationTests) { dependsOn { integrationTestTask } }
+}
+integrationTestTask.mustRunAfter checkAll
 
 // Upload source and binaries for all subprojects
 task uploadAll { dependsOn { subproj.uploadArchives } }
 
 // Upload source and binaries, but only if checks pass for all subprojects
-task checkAndUploadAll { dependsOn { [checkAll, uploadAll] } }
-uploadAll.mustRunAfter checkAll
+task checkAndUploadAll { dependsOn { [checkAllWithIntegrationIfNeeded, uploadAll] } }
+uploadAll.mustRunAfter checkAllWithIntegrationIfNeeded
 
 // Produce Gradle Wrapper scripts for running Gradle on machines that don't have Gradle installed
 task wrapper(type: Wrapper) { gradleVersion = '1.7' }


### PR DESCRIPTION
Cheddar's root build script has been updated to optionally run integration tests, like this:
gradle -DrunIntegrationTests checkAndUploadAll
Integration tests will run after unit tests but before uploading artifacts.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>