### PR TITLE
Added equals methods to Cloud Search Query subclasses

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/QueryBuilder.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/QueryBuilder.java
@@ -19,7 +19,7 @@ package com.clicktravel.infrastructure.persistence.aws.cloudsearch;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.List;
+import java.util.Set;
 
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
@@ -29,7 +29,7 @@ import com.clicktravel.cheddar.infrastructure.persistence.document.search.query.
 
 /**
  * Class Responsible for constructing cloudsearch query strings from Query.class
- *
+ * 
  */
 public class QueryBuilder implements QueryVisitor {
 
@@ -94,7 +94,7 @@ public class QueryBuilder implements QueryVisitor {
         writeBooleanQuery(orQuery.getQueries(), "or");
     }
 
-    private void writeBooleanQuery(final List<StructuredQuery> subqueries, final String operator) {
+    private void writeBooleanQuery(final Set<StructuredQuery> subqueries, final String operator) {
         write('(');
         write(operator);
         for (final StructuredQuery query : subqueries) {

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/StructuredQueryBuilderTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/StructuredQueryBuilderTest.java
@@ -194,9 +194,9 @@ public class StructuredQueryBuilderTest {
 
         // Then
         assertTrue(result.startsWith("(and"));
+        assertTrue(result.contains("(term field=" + field1Name + " '" + value1 + "')"));
+        assertTrue(result.contains("(term field=" + field2Name + " '" + value2 + "')"));
         assertTrue(result.endsWith(")"));
-        assertTrue(result.matches(".*(term field=" + field1Name + " '" + value1 + "').*(term field=" + field2Name
-                + " '" + value2 + "')*"));
     }
 
     @Test
@@ -216,8 +216,8 @@ public class StructuredQueryBuilderTest {
 
         // Then
         assertTrue(result.startsWith("(or"));
+        assertTrue(result.contains("(term field=" + field1Name + " '" + value1 + "')"));
+        assertTrue(result.contains("(term field=" + field2Name + " '" + value2 + "')"));
         assertTrue(result.endsWith(")"));
-        assertTrue(result.matches(".*(term field=" + field1Name + " '" + value1 + "').*(term field=" + field2Name
-                + " '" + value2 + "')*"));
     }
 }

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/StructuredQueryBuilderTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/StructuredQueryBuilderTest.java
@@ -21,6 +21,7 @@ import static com.clicktravel.common.random.Randoms.randomDouble;
 import static com.clicktravel.common.random.Randoms.randomInt;
 import static com.clicktravel.common.random.Randoms.randomString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 
@@ -192,9 +193,10 @@ public class StructuredQueryBuilderTest {
         final String result = builder.buildQuery(andQuery);
 
         // Then
-        final String expected = "(and (term field=" + field1Name + " '" + value1 + "') (term field=" + field2Name
-                + " '" + value2 + "'))";
-        assertEquals(expected, result);
+        assertTrue(result.startsWith("(and"));
+        assertTrue(result.endsWith(")"));
+        assertTrue(result.matches(".*(term field=" + field1Name + " '" + value1 + "').*(term field=" + field2Name
+                + " '" + value2 + "')*"));
     }
 
     @Test
@@ -213,8 +215,9 @@ public class StructuredQueryBuilderTest {
         final String result = builder.buildQuery(orQuery);
 
         // Then
-        final String expected = "(or (term field=" + field1Name + " '" + value1 + "') (term field=" + field2Name + " '"
-                + value2 + "'))";
-        assertEquals(expected, result);
+        assertTrue(result.startsWith("(or"));
+        assertTrue(result.endsWith(")"));
+        assertTrue(result.matches(".*(term field=" + field1Name + " '" + value1 + "').*(term field=" + field2Name
+                + " '" + value2 + "')*"));
     }
 }

--- a/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/document/search/mock/SearchParameter.java
+++ b/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/document/search/mock/SearchParameter.java
@@ -18,7 +18,6 @@ package com.clicktravel.infrastructure.persistence.inmemory.document.search.mock
 
 import com.clicktravel.cheddar.infrastructure.persistence.document.search.Document;
 import com.clicktravel.cheddar.infrastructure.persistence.document.search.options.SearchOptions;
-import com.clicktravel.cheddar.infrastructure.persistence.document.search.query.LuceneQuery;
 import com.clicktravel.cheddar.infrastructure.persistence.document.search.query.Query;
 
 public class SearchParameter {
@@ -60,14 +59,13 @@ public class SearchParameter {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((documentClass == null) ? 0 : documentClass.hashCode());
-        result = prime * result + ((searchOptions == null) ? 0 : searchOptions.hashCode());
         result = prime * result + ((query == null) ? 0 : query.hashCode());
+        result = prime * result + ((searchOptions == null) ? 0 : searchOptions.hashCode());
         result = prime * result + ((size == null) ? 0 : size.hashCode());
         result = prime * result + ((start == null) ? 0 : start.hashCode());
         return result;
     }
 
-    // TODO change this back to default equals method when Query concrete equals method implemented in Cheddar
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {
@@ -87,19 +85,19 @@ public class SearchParameter {
         } else if (!documentClass.equals(other.documentClass)) {
             return false;
         }
+        if (query == null) {
+            if (other.query != null) {
+                return false;
+            }
+        } else if (!query.equals(other.query)) {
+            return false;
+        }
         if (searchOptions == null) {
             if (other.searchOptions != null) {
                 return false;
             }
         } else if (!searchOptions.equals(other.searchOptions)) {
             return false;
-        }
-        if (query == null) {
-            if (other.query != null) {
-                return false;
-            }
-        } else {
-            return checkQueryEquals(query, other.query);
         }
         if (size == null) {
             if (other.size != null) {
@@ -116,26 +114,6 @@ public class SearchParameter {
             return false;
         }
         return true;
-    }
-
-    // TODO temporary method to allow cloud search service tests to work with lucene queries
-    private boolean checkQueryEquals(final Query query, final Query otherQuery) {
-        if (query.queryType().equals(otherQuery.queryType())) {
-
-            switch (query.queryType()) {
-                case LUCENE:
-                    final String queryString = ((LuceneQuery) query).getQuery();
-                    final String otherQueryString = ((LuceneQuery) otherQuery).getQuery();
-                    if (queryString.equals(otherQueryString)) {
-                        return true;
-                    }
-                    break;
-                default:
-                    return false;
-            }
-
-        }
-        return false;
     }
 
 }

--- a/cheddar/cheddar-integration-mocks/src/test/java/com/clicktravel/infrastructure/persistence/inmemory/document/search/mock/InMemoryMockDocumentSearchEngineTest.java
+++ b/cheddar/cheddar-integration-mocks/src/test/java/com/clicktravel/infrastructure/persistence/inmemory/document/search/mock/InMemoryMockDocumentSearchEngineTest.java
@@ -17,41 +17,26 @@
 package com.clicktravel.infrastructure.persistence.inmemory.document.search.mock;
 
 import static com.clicktravel.common.random.Randoms.randomInt;
-import static com.clicktravel.common.random.Randoms.randomString;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import com.clicktravel.cheddar.infrastructure.persistence.document.search.Document;
 import com.clicktravel.cheddar.infrastructure.persistence.document.search.DocumentSearchResponse;
 import com.clicktravel.cheddar.infrastructure.persistence.document.search.options.SearchOptions;
-import com.clicktravel.cheddar.infrastructure.persistence.document.search.query.LuceneQuery;
 import com.clicktravel.cheddar.infrastructure.persistence.document.search.query.Query;
-import com.clicktravel.cheddar.infrastructure.persistence.document.search.query.QueryType;
 import com.clicktravel.infrastructure.persistence.inmemory.document.search.StubDocument;
 import com.clicktravel.infrastructure.persistence.inmemory.document.search.mock.exception.SearchExpectationException;
 import com.clicktravel.infrastructure.persistence.inmemory.document.search.mock.exception.UnexpectedSearchException;
 
 public class InMemoryMockDocumentSearchEngineTest {
-
-    // TODO can remove this instance variable and setup after framework change to implement equals
-    private LuceneQuery query;
-
-    @Before
-    public void setUp() {
-        query = mock(LuceneQuery.class);
-        when(query.queryType()).thenReturn(QueryType.LUCENE);
-        when(query.getQuery()).thenReturn(randomString());
-    }
 
     @Test
     public void shouldUpdateDocument_withDocument() throws Exception {
@@ -118,6 +103,7 @@ public class InMemoryMockDocumentSearchEngineTest {
     @Test
     public void shouldStubQueryBehaviour_withMatchingQuery() throws Exception {
         // Given
+        final Query query = mock(Query.class);
         final Integer start = randomInt(Integer.MAX_VALUE);
         final Integer size = randomInt(Integer.MAX_VALUE);
         final Class<StubDocument> documentClass = StubDocument.class;
@@ -139,6 +125,7 @@ public class InMemoryMockDocumentSearchEngineTest {
     @Test
     public void shouldNotStubQueryBehaviour_withNonMatchingQuery() throws Exception {
         // Given
+        final Query query = mock(Query.class);
         final Integer start = randomInt(Integer.MAX_VALUE);
         final Integer size = randomInt(Integer.MAX_VALUE);
         final Class<StubDocument> documentClass = StubDocument.class;
@@ -163,6 +150,7 @@ public class InMemoryMockDocumentSearchEngineTest {
     @Test
     public void shouldNotStubQueryBehaviour_withMatchingQueryButOngoingStubbing() throws Exception {
         // Given
+        final Query query = mock(Query.class);
         final Integer start = randomInt(Integer.MAX_VALUE);
         final Integer size = randomInt(Integer.MAX_VALUE);
         final Class<StubDocument> documentClass = StubDocument.class;

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/AndQuery.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/AndQuery.java
@@ -40,4 +40,35 @@ public class AndQuery extends StructuredQuery {
     public void accept(final QueryVisitor visitor) {
         visitor.visit(this);
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((queries == null) ? 0 : queries.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final AndQuery other = (AndQuery) obj;
+        if (queries == null) {
+            if (other.queries != null) {
+                return false;
+            }
+        } else if (!queries.equals(other.queries)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/AndQuery.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/AndQuery.java
@@ -16,13 +16,13 @@
  */
 package com.clicktravel.cheddar.infrastructure.persistence.document.search.query;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 public class AndQuery extends StructuredQuery {
 
-    private final List<StructuredQuery> queries = new ArrayList<>();
+    private final Set<StructuredQuery> queries = new HashSet<>();
 
     public AndQuery(final Collection<StructuredQuery> queries) {
         this.queries.addAll(queries);
@@ -32,7 +32,7 @@ public class AndQuery extends StructuredQuery {
         queries.add(query);
     }
 
-    public List<StructuredQuery> getQueries() {
+    public Set<StructuredQuery> getQueries() {
         return queries;
     }
 

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/LuceneQuery.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/LuceneQuery.java
@@ -38,4 +38,34 @@ public class LuceneQuery extends Query {
         return QueryType.LUCENE;
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((query == null) ? 0 : query.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final LuceneQuery other = (LuceneQuery) obj;
+        if (query == null) {
+            if (other.query != null) {
+                return false;
+            }
+        } else if (!query.equals(other.query)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/OrQuery.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/OrQuery.java
@@ -40,4 +40,35 @@ public class OrQuery extends StructuredQuery {
     public void accept(final QueryVisitor visitor) {
         visitor.visit(this);
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((queries == null) ? 0 : queries.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final OrQuery other = (OrQuery) obj;
+        if (queries == null) {
+            if (other.queries != null) {
+                return false;
+            }
+        } else if (!queries.equals(other.queries)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/OrQuery.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/OrQuery.java
@@ -16,13 +16,13 @@
  */
 package com.clicktravel.cheddar.infrastructure.persistence.document.search.query;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 public class OrQuery extends StructuredQuery {
 
-    private final List<StructuredQuery> queries = new ArrayList<>();
+    private final Set<StructuredQuery> queries = new HashSet<>();
 
     public OrQuery(final Collection<StructuredQuery> queries) {
         this.queries.addAll(queries);
@@ -32,7 +32,7 @@ public class OrQuery extends StructuredQuery {
         queries.add(query);
     }
 
-    public List<StructuredQuery> getQueries() {
+    public Set<StructuredQuery> getQueries() {
         return queries;
     }
 

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/Query.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/Query.java
@@ -25,4 +25,7 @@ public abstract class Query {
      * @return
      */
     public abstract QueryType queryType();
+
+    @Override
+    public abstract boolean equals(final Object obj);
 }

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/RangeQuery.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/RangeQuery.java
@@ -79,4 +79,59 @@ public class RangeQuery extends StructuredQuery {
     public void accept(final QueryVisitor visitor) {
         visitor.visit(this);
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+        result = prime * result + ((lowerBound == null) ? 0 : lowerBound.hashCode());
+        result = prime * result + (lowerBoundInclusive ? 1231 : 1237);
+        result = prime * result + ((upperBound == null) ? 0 : upperBound.hashCode());
+        result = prime * result + (upperBoundInclusive ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final RangeQuery other = (RangeQuery) obj;
+        if (fieldName == null) {
+            if (other.fieldName != null) {
+                return false;
+            }
+        } else if (!fieldName.equals(other.fieldName)) {
+            return false;
+        }
+        if (lowerBound == null) {
+            if (other.lowerBound != null) {
+                return false;
+            }
+        } else if (!lowerBound.equals(other.lowerBound)) {
+            return false;
+        }
+        if (lowerBoundInclusive != other.lowerBoundInclusive) {
+            return false;
+        }
+        if (upperBound == null) {
+            if (other.upperBound != null) {
+                return false;
+            }
+        } else if (!upperBound.equals(other.upperBound)) {
+            return false;
+        }
+        if (upperBoundInclusive != other.upperBoundInclusive) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/SimpleQuery.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/SimpleQuery.java
@@ -39,4 +39,34 @@ public class SimpleQuery extends Query {
         return QueryType.SIMPLE;
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((query == null) ? 0 : query.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final SimpleQuery other = (SimpleQuery) obj;
+        if (query == null) {
+            if (other.query != null) {
+                return false;
+            }
+        } else if (!query.equals(other.query)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/TermQuery.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/TermQuery.java
@@ -62,4 +62,43 @@ public class TermQuery extends StructuredQuery {
     public void accept(final QueryVisitor visitor) {
         visitor.visit(this);
     }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((fieldName == null) ? 0 : fieldName.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final TermQuery other = (TermQuery) obj;
+        if (fieldName == null) {
+            if (other.fieldName != null) {
+                return false;
+            }
+        } else if (!fieldName.equals(other.fieldName)) {
+            return false;
+        }
+        if (value == null) {
+            if (other.value != null) {
+                return false;
+            }
+        } else if (!value.equals(other.value)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/LuceneQueryTest.java
+++ b/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/LuceneQueryTest.java
@@ -17,6 +17,7 @@
 package com.clicktravel.cheddar.infrastructure.persistence.document.search.query;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -28,6 +29,20 @@ public class LuceneQueryTest {
     public void shouldBeLuceneQuery() {
         final LuceneQuery query = new LuceneQuery(Randoms.randomString());
         assertEquals(QueryType.LUCENE, query.queryType());
+    }
+
+    @Test
+    public void shouldBeEqual_withSameValues() {
+        // Given
+        final String query = Randoms.randomString();
+        final LuceneQuery luceneQuery = new LuceneQuery(query);
+        final LuceneQuery otherLuceneQuery = new LuceneQuery(query);
+
+        // When
+        final boolean equals = luceneQuery.equals(otherLuceneQuery);
+
+        // Then
+        assertTrue(equals);
     }
 
 }

--- a/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/SimpleQueryTest.java
+++ b/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/SimpleQueryTest.java
@@ -17,6 +17,7 @@
 package com.clicktravel.cheddar.infrastructure.persistence.document.search.query;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -28,6 +29,20 @@ public class SimpleQueryTest {
     public void shouldBeSimpleQuery() {
         final SimpleQuery query = new SimpleQuery(Randoms.randomString());
         assertEquals(QueryType.SIMPLE, query.queryType());
+    }
+
+    @Test
+    public void shouldBeEqual_withSameValues() {
+        // Given
+        final String query = Randoms.randomString();
+        final SimpleQuery luceneQuery = new SimpleQuery(query);
+        final SimpleQuery otherLuceneQuery = new SimpleQuery(query);
+
+        // When
+        final boolean equals = luceneQuery.equals(otherLuceneQuery);
+
+        // Then
+        assertTrue(equals);
     }
 
 }

--- a/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/StructuredQueryTest.java
+++ b/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/document/search/query/StructuredQueryTest.java
@@ -16,11 +16,16 @@
  */
 package com.clicktravel.cheddar.infrastructure.persistence.document.search.query;
 
+import static com.clicktravel.common.random.Randoms.randomBoolean;
+import static com.clicktravel.common.random.Randoms.randomDateTime;
+import static com.clicktravel.common.random.Randoms.randomString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 import java.util.HashSet;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 
 import com.clicktravel.common.random.Randoms;
@@ -40,6 +45,41 @@ public class StructuredQueryTest {
         queries.add(term);
         assertEquals(QueryType.STRUCTURED, new AndQuery(queries).queryType());
         assertEquals(QueryType.STRUCTURED, new OrQuery(queries).queryType());
+    }
+
+    @Test
+    public void shouldBeEqualRangeQuerys_withSameValues() {
+        // Given
+        final String fieldName = randomString();
+        final DateTime lowerBound = randomDateTime();
+        final DateTime upperBound = randomDateTime();
+        final boolean lowerBoundInclusive = randomBoolean();
+        final boolean upperBoundInclusive = randomBoolean();
+        final RangeQuery rangeQuery = new RangeQuery(fieldName, lowerBound, upperBound, lowerBoundInclusive,
+                upperBoundInclusive);
+        final RangeQuery otherRangeQuery = new RangeQuery(fieldName, lowerBound, upperBound, lowerBoundInclusive,
+                upperBoundInclusive);
+
+        // When
+        final boolean equals = rangeQuery.equals(otherRangeQuery);
+
+        // Then
+        assertTrue(equals);
+    }
+
+    @Test
+    public void shouldBeEqualTermQuerys_withSameValues() {
+        // Given
+        final String fieldName = randomString();
+        final String value = randomString();
+        final TermQuery termQuery = new TermQuery(fieldName, value);
+        final TermQuery otherTermQuery = new TermQuery(fieldName, value);
+
+        // When
+        final boolean equals = termQuery.equals(otherTermQuery);
+
+        // Then
+        assertTrue(equals);
     }
 
 }


### PR DESCRIPTION
In order to assert correctly on equality in Query subclasses, the equals method had to be implemented. The lack of these methods stopped mocks used during testing from working as intended. Refactoring to remove temporary code has also been added now that a more suitable implementation has been reached.