### PR TITLE
Removed server error only exception handling when failures occur while receiving messages

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsQueueResource.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsQueueResource.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.amazonaws.AmazonServiceException;
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.policy.Policy;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.*;
@@ -115,9 +115,9 @@ public class SqsQueueResource {
         while (true) {
             try {
                 return amazonSqsClient.receiveMessage(receiveMessageRequest).getMessages();
-            } catch (final AmazonServiceException amazonServiceException) {
-                logger.error("Error receiving SQS messages on queue:[" + queueName + "]", amazonServiceException);
-                // Ignore all amazon errors and hope SQS recovers
+            } catch (final AmazonClientException amazonClientException) {
+                logger.error("Error receiving SQS messages on queue:[" + queueName + "]", amazonClientException);
+                // Ignore all amazon specific errors and hope SQS recovers
                 Thread.sleep(SQS_SERVICE_ERROR_PAUSE_MILLIS);
             }
         }

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsQueueResource.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsQueueResource.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.auth.policy.Policy;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.*;
@@ -118,12 +117,8 @@ public class SqsQueueResource {
                 return amazonSqsClient.receiveMessage(receiveMessageRequest).getMessages();
             } catch (final AmazonServiceException amazonServiceException) {
                 logger.error("Error receiving SQS messages on queue:[" + queueName + "]", amazonServiceException);
-                // Ignore service errors (5xx) and hope SQS recovers
-                if (amazonServiceException.getErrorType().equals(ErrorType.Service)) {
-                    Thread.sleep(SQS_SERVICE_ERROR_PAUSE_MILLIS);
-                } else {
-                    throw amazonServiceException;
-                }
+                // Ignore all amazon errors and hope SQS recovers
+                Thread.sleep(SQS_SERVICE_ERROR_PAUSE_MILLIS);
             }
         }
     }


### PR DESCRIPTION
When the SQS queue resource was receiving a message from a queue if an amazon exception occurred it was only retrying if it was of type 'SERVICE'. This turns out to be insufficient as in practice if the host cannot be reached an IOException is thrown which results in a AmazonClientException. This change makes it so that any amazon exceptions result in a logged message and retry just as the requirements stated.