### PR TITLE
[no-jira] Allow BeanAssert to work with Joda DateTime

### DIFF
--- a/commons/commons-test/src/main/java/com/clicktravel/common/test/BeanAssert.java
+++ b/commons/commons-test/src/main/java/com/clicktravel/common/test/BeanAssert.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.*;
 
+import org.joda.time.DateTime;
 import org.mockito.internal.util.collections.Sets;
 
 import com.clicktravel.common.random.Randoms;
@@ -106,6 +107,7 @@ public class BeanAssert {
         supportedPropertyTypes.put(Character.class, randomChar());
         supportedPropertyTypes.put(String.class, randomString(1000));
         supportedPropertyTypes.put(Date.class, new Date(randomDateTime().getMillis()));
+        supportedPropertyTypes.put(DateTime.class, randomDateTime());
         supportedPropertyTypes.put(Set.class, Sets.newSet(randomLong(), randomLong(), randomLong()));
         supportedPropertyTypes.put(BigDecimal.class, Randoms.randomBigDecimal(10000, randomInt(5)));
 


### PR DESCRIPTION
This allow us to use Joda DateTime within our persistence model instead of forcing String/long conversion.

Mockito cannot mock a DateTime, so we need to put in a given (random) value.