### PR TITLE
[TRAV-192] increment version numbers when updating objects using doc API

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/AbstractDynamoDbTemplate.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/AbstractDynamoDbTemplate.java
@@ -49,6 +49,8 @@ public abstract class AbstractDynamoDbTemplate extends AbstractDatabaseTemplate 
     private static final String SEQUENCE_NAME_ATTRIBUTE = "name";
     private static final String SEQUENCE_CURRENT_VALUE_ATTRIBUTE = "currentValue";
 
+    protected static final String VERSION_ATTRIBUTE = "version";
+
     public AbstractDynamoDbTemplate(final DatabaseSchemaHolder databaseSchemaHolder) {
         this.databaseSchemaHolder = databaseSchemaHolder;
         itemConfigurationMap = new HashMap<>();

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDbTemplate.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDbTemplate.java
@@ -43,8 +43,6 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private static final String VERSION_ATTRIBUTE = "version";
-
     public DynamoDbTemplate(final DatabaseSchemaHolder databaseSchemaHolder) {
         super(databaseSchemaHolder);
     }

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplateTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplateTest.java
@@ -19,6 +19,7 @@ package com.clicktravel.infrastructure.persistence.aws.dynamodb;
 import static com.clicktravel.common.random.Randoms.randomId;
 import static com.clicktravel.common.random.Randoms.randomString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -33,9 +34,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -60,9 +59,6 @@ import com.clicktravel.common.random.Randoms;
 @PrepareForTest({ DynamoDocumentStoreTemplate.class })
 public class DynamoDocumentStoreTemplateTest {
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     private DatabaseSchemaHolder mockDatabaseSchemaHolder;
     private String schemaName;
     private String tableName;
@@ -78,7 +74,7 @@ public class DynamoDocumentStoreTemplateTest {
         mockAmazonDynamoDbClient = mock(AmazonDynamoDB.class);
         mockDynamoDBClient = mock(DynamoDB.class);
         whenNew(DynamoDB.class).withParameterTypes(AmazonDynamoDB.class).withArguments(eq(mockAmazonDynamoDbClient))
-                .thenReturn(mockDynamoDBClient);
+        .thenReturn(mockDynamoDBClient);
     }
 
     @SuppressWarnings("deprecation")
@@ -140,13 +136,17 @@ public class DynamoDocumentStoreTemplateTest {
         when(mockTableItem.toJSON()).thenReturn(dynamoDocumentStoreTemplate.itemToString(stubItem));
 
         doThrow(RuntimeException.class).when(mockTable).putItem(any(PutItemSpec.class));
-
-        exception.expect(RuntimeException.class);
+        RuntimeException thrownException = null;
 
         // When
-        dynamoDocumentStoreTemplate.create(stubItem);
+        try {
+            dynamoDocumentStoreTemplate.create(stubItem);
+        } catch (final RuntimeException runtimeException) {
+            thrownException = runtimeException;
+        }
 
         // Then
+        assertNotNull(thrownException);
     }
 
     @SuppressWarnings("deprecation")
@@ -208,12 +208,16 @@ public class DynamoDocumentStoreTemplateTest {
 
         when(mockTable.getItem(any(GetItemSpec.class))).thenReturn(null);
 
-        exception.expect(NonExistentItemException.class);
-
+        NonExistentItemException thrownException = null;
         // When
-        dynamoDocumentStoreTemplate.read(itemId, StubItem.class);
+        try {
+            dynamoDocumentStoreTemplate.read(itemId, StubItem.class);
+        } catch (final NonExistentItemException nonExistentItemException) {
+            thrownException = nonExistentItemException;
+        }
 
         // Then
+        assertNotNull(thrownException);
     }
 
     @SuppressWarnings("deprecation")
@@ -238,12 +242,16 @@ public class DynamoDocumentStoreTemplateTest {
 
         when(mockTableItem.toJSON()).thenReturn("");
 
-        exception.expect(NonExistentItemException.class);
-
+        NonExistentItemException thrownException = null;
         // When
-        dynamoDocumentStoreTemplate.read(itemId, StubItem.class);
+        try {
+            dynamoDocumentStoreTemplate.read(itemId, StubItem.class);
+        } catch (final NonExistentItemException nonExistentItemException) {
+            thrownException = nonExistentItemException;
+        }
 
         // Then
+        assertNotNull(thrownException);
     }
 
     @SuppressWarnings("deprecation")
@@ -306,12 +314,17 @@ public class DynamoDocumentStoreTemplateTest {
 
         doThrow(ConditionalCheckFailedException.class).when(mockTable).putItem(any(PutItemSpec.class));
 
-        exception.expect(OptimisticLockException.class);
+        OptimisticLockException thrownException = null;
 
         // When
-        dynamoDocumentStoreTemplate.update(stubItem);
+        try {
+            dynamoDocumentStoreTemplate.update(stubItem);
+        } catch (final OptimisticLockException optimisticLockException) {
+            thrownException = optimisticLockException;
+        }
 
         // Then
+        assertNotNull(thrownException);
     }
 
     @SuppressWarnings("deprecation")

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplateTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplateTest.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.infrastructure.persistence.aws.dynamodb;
+
+import static com.clicktravel.common.random.Randoms.randomId;
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.document.spec.DeleteItemSpec;
+import com.amazonaws.services.dynamodbv2.document.spec.GetItemSpec;
+import com.amazonaws.services.dynamodbv2.document.spec.PutItemSpec;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
+import com.clicktravel.cheddar.infrastructure.persistence.database.ItemId;
+import com.clicktravel.cheddar.infrastructure.persistence.database.configuration.DatabaseSchemaHolder;
+import com.clicktravel.cheddar.infrastructure.persistence.database.configuration.ItemConfiguration;
+import com.clicktravel.cheddar.infrastructure.persistence.database.exception.NonExistentItemException;
+import com.clicktravel.cheddar.infrastructure.persistence.database.exception.OptimisticLockException;
+import com.clicktravel.common.random.Randoms;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ DynamoDocumentStoreTemplate.class })
+public class DynamoDocumentStoreTemplateTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private DatabaseSchemaHolder mockDatabaseSchemaHolder;
+    private String schemaName;
+    private String tableName;
+    private AmazonDynamoDB mockAmazonDynamoDbClient;
+    private DynamoDB mockDynamoDBClient;
+
+    @Before
+    public void setup() throws Exception {
+        schemaName = randomString(10);
+        tableName = randomString(10);
+        mockDatabaseSchemaHolder = mock(DatabaseSchemaHolder.class);
+        when(mockDatabaseSchemaHolder.schemaName()).thenReturn(schemaName);
+        mockAmazonDynamoDbClient = mock(AmazonDynamoDB.class);
+        mockDynamoDBClient = mock(DynamoDB.class);
+        whenNew(DynamoDB.class).withParameterTypes(AmazonDynamoDB.class).withArguments(eq(mockAmazonDynamoDbClient))
+                .thenReturn(mockDynamoDBClient);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldCreate_withItem() {
+        // Given
+        final ItemId itemId = new ItemId(randomId());
+        final StubItem stubItem = generateRandomStubItem(itemId);
+
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(StubItem.class, tableName);
+        final Collection<ItemConfiguration> itemConfigurations = Arrays.asList(itemConfiguration);
+        when(mockDatabaseSchemaHolder.itemConfigurations()).thenReturn(itemConfigurations);
+
+        final Table mockTable = mock(Table.class);
+        when(mockDynamoDBClient.getTable(any(String.class))).thenReturn(mockTable);
+
+        final DynamoDocumentStoreTemplate dynamoDocumentStoreTemplate = new DynamoDocumentStoreTemplate(
+                mockDatabaseSchemaHolder);
+        dynamoDocumentStoreTemplate.initialize(mockAmazonDynamoDbClient);
+
+        final Item mockTableItem = mock(Item.class);
+        when(mockTableItem.toJSON()).thenReturn(dynamoDocumentStoreTemplate.itemToString(stubItem));
+
+        // When
+        final StubItem returnedItem = dynamoDocumentStoreTemplate.create(stubItem);
+
+        // Then
+        final ArgumentCaptor<PutItemSpec> getItemRequestCaptor = ArgumentCaptor.forClass(PutItemSpec.class);
+        verify(mockTable).putItem(getItemRequestCaptor.capture());
+
+        final PutItemSpec spec = getItemRequestCaptor.getValue();
+        assertEquals(itemId.value(), spec.getItem().get("id"));
+
+        assertEquals(itemId.value(), returnedItem.getId());
+        assertEquals(stubItem.getStringProperty(), returnedItem.getStringProperty());
+        assertEquals(stubItem.getStringProperty2(), returnedItem.getStringProperty2());
+        assertEquals(stubItem.getStringSetProperty(), returnedItem.getStringSetProperty());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldNotCreate_withItem() {
+        // Given
+        final ItemId itemId = new ItemId(randomId());
+        final StubItem stubItem = generateRandomStubItem(itemId);
+
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(StubItem.class, tableName);
+        final Collection<ItemConfiguration> itemConfigurations = Arrays.asList(itemConfiguration);
+        when(mockDatabaseSchemaHolder.itemConfigurations()).thenReturn(itemConfigurations);
+
+        final Table mockTable = mock(Table.class);
+        when(mockDynamoDBClient.getTable(any(String.class))).thenReturn(mockTable);
+
+        final DynamoDocumentStoreTemplate dynamoDocumentStoreTemplate = new DynamoDocumentStoreTemplate(
+                mockDatabaseSchemaHolder);
+        dynamoDocumentStoreTemplate.initialize(mockAmazonDynamoDbClient);
+
+        final Item mockTableItem = mock(Item.class);
+        when(mockTableItem.toJSON()).thenReturn(dynamoDocumentStoreTemplate.itemToString(stubItem));
+
+        doThrow(RuntimeException.class).when(mockTable).putItem(any(PutItemSpec.class));
+
+        exception.expect(RuntimeException.class);
+
+        // When
+        dynamoDocumentStoreTemplate.create(stubItem);
+
+        // Then
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldRead_withItemIdAndItemClass() throws Exception {
+        // Given
+        final ItemId itemId = new ItemId(randomId());
+
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(StubItem.class, tableName);
+        final Collection<ItemConfiguration> itemConfigurations = Arrays.asList(itemConfiguration);
+        when(mockDatabaseSchemaHolder.itemConfigurations()).thenReturn(itemConfigurations);
+
+        final DynamoDocumentStoreTemplate dynamoDocumentStoreTemplate = new DynamoDocumentStoreTemplate(
+                mockDatabaseSchemaHolder);
+        dynamoDocumentStoreTemplate.initialize(mockAmazonDynamoDbClient);
+
+        final Table mockTable = mock(Table.class);
+        when(mockDynamoDBClient.getTable(any(String.class))).thenReturn(mockTable);
+
+        final Item mockTableItem = mock(Item.class);
+        when(mockTable.getItem(any(GetItemSpec.class))).thenReturn(mockTableItem);
+
+        final StubItem stubItem = generateRandomStubItem(itemId);
+        when(mockTableItem.toJSON()).thenReturn(dynamoDocumentStoreTemplate.itemToString(stubItem));
+
+        // When
+        final StubItem returnedItem = dynamoDocumentStoreTemplate.read(itemId, StubItem.class);
+
+        // Then
+        final ArgumentCaptor<GetItemSpec> getItemRequestCaptor = ArgumentCaptor.forClass(GetItemSpec.class);
+        verify(mockTable).getItem(getItemRequestCaptor.capture());
+
+        final GetItemSpec spec = getItemRequestCaptor.getValue();
+        assertEquals(1, spec.getKeyComponents().size());
+        assertEquals(itemId.value(), spec.getKeyComponents().iterator().next().getValue());
+
+        assertEquals(itemId.value(), returnedItem.getId());
+        assertEquals(stubItem.getStringProperty(), returnedItem.getStringProperty());
+        assertEquals(stubItem.getStringProperty2(), returnedItem.getStringProperty2());
+        assertEquals(stubItem.getStringSetProperty(), returnedItem.getStringSetProperty());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldNotRead_withNonExistentItemExceptionNoItem() throws Exception {
+        // Given
+        final ItemId itemId = new ItemId(randomId());
+
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(StubItem.class, tableName);
+        final Collection<ItemConfiguration> itemConfigurations = Arrays.asList(itemConfiguration);
+        when(mockDatabaseSchemaHolder.itemConfigurations()).thenReturn(itemConfigurations);
+
+        final DynamoDocumentStoreTemplate dynamoDocumentStoreTemplate = new DynamoDocumentStoreTemplate(
+                mockDatabaseSchemaHolder);
+        dynamoDocumentStoreTemplate.initialize(mockAmazonDynamoDbClient);
+
+        final Table mockTable = mock(Table.class);
+        when(mockDynamoDBClient.getTable(any(String.class))).thenReturn(mockTable);
+
+        when(mockTable.getItem(any(GetItemSpec.class))).thenReturn(null);
+
+        exception.expect(NonExistentItemException.class);
+
+        // When
+        dynamoDocumentStoreTemplate.read(itemId, StubItem.class);
+
+        // Then
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldNotRead_withNonExistentItemExceptionNoContent() throws Exception {
+        // Given
+        final ItemId itemId = new ItemId(randomId());
+
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(StubItem.class, tableName);
+        final Collection<ItemConfiguration> itemConfigurations = Arrays.asList(itemConfiguration);
+        when(mockDatabaseSchemaHolder.itemConfigurations()).thenReturn(itemConfigurations);
+
+        final DynamoDocumentStoreTemplate dynamoDocumentStoreTemplate = new DynamoDocumentStoreTemplate(
+                mockDatabaseSchemaHolder);
+        dynamoDocumentStoreTemplate.initialize(mockAmazonDynamoDbClient);
+
+        final Table mockTable = mock(Table.class);
+        when(mockDynamoDBClient.getTable(any(String.class))).thenReturn(mockTable);
+
+        final Item mockTableItem = mock(Item.class);
+        when(mockTable.getItem(any(GetItemSpec.class))).thenReturn(mockTableItem);
+
+        when(mockTableItem.toJSON()).thenReturn("");
+
+        exception.expect(NonExistentItemException.class);
+
+        // When
+        dynamoDocumentStoreTemplate.read(itemId, StubItem.class);
+
+        // Then
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldUpdate_withItem() {
+        // Given
+        final ItemId itemId = new ItemId(randomId());
+        final StubItem stubItem = generateRandomStubItem(itemId);
+
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(StubItem.class, tableName);
+        final Collection<ItemConfiguration> itemConfigurations = Arrays.asList(itemConfiguration);
+        when(mockDatabaseSchemaHolder.itemConfigurations()).thenReturn(itemConfigurations);
+
+        final Table mockTable = mock(Table.class);
+        when(mockDynamoDBClient.getTable(any(String.class))).thenReturn(mockTable);
+
+        final DynamoDocumentStoreTemplate dynamoDocumentStoreTemplate = new DynamoDocumentStoreTemplate(
+                mockDatabaseSchemaHolder);
+        dynamoDocumentStoreTemplate.initialize(mockAmazonDynamoDbClient);
+
+        final Item mockTableItem = mock(Item.class);
+        when(mockTableItem.toJSON()).thenReturn(dynamoDocumentStoreTemplate.itemToString(stubItem));
+
+        // When
+        final StubItem returnedItem = dynamoDocumentStoreTemplate.update(stubItem);
+
+        // Then
+        final ArgumentCaptor<PutItemSpec> getItemRequestCaptor = ArgumentCaptor.forClass(PutItemSpec.class);
+        verify(mockTable).putItem(getItemRequestCaptor.capture());
+
+        final PutItemSpec spec = getItemRequestCaptor.getValue();
+        assertEquals(itemId.value(), spec.getItem().get("id"));
+
+        assertEquals(itemId.value(), returnedItem.getId());
+        assertEquals(stubItem.getStringProperty(), returnedItem.getStringProperty());
+        assertEquals(stubItem.getStringProperty2(), returnedItem.getStringProperty2());
+        assertEquals(stubItem.getStringSetProperty(), returnedItem.getStringSetProperty());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldNotUpdate_withItem() {
+        // Given
+        final ItemId itemId = new ItemId(randomId());
+        final StubItem stubItem = generateRandomStubItem(itemId);
+
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(StubItem.class, tableName);
+        final Collection<ItemConfiguration> itemConfigurations = Arrays.asList(itemConfiguration);
+        when(mockDatabaseSchemaHolder.itemConfigurations()).thenReturn(itemConfigurations);
+
+        final Table mockTable = mock(Table.class);
+        when(mockDynamoDBClient.getTable(any(String.class))).thenReturn(mockTable);
+
+        final DynamoDocumentStoreTemplate dynamoDocumentStoreTemplate = new DynamoDocumentStoreTemplate(
+                mockDatabaseSchemaHolder);
+        dynamoDocumentStoreTemplate.initialize(mockAmazonDynamoDbClient);
+
+        final Item mockTableItem = mock(Item.class);
+        when(mockTableItem.toJSON()).thenReturn(dynamoDocumentStoreTemplate.itemToString(stubItem));
+
+        doThrow(ConditionalCheckFailedException.class).when(mockTable).putItem(any(PutItemSpec.class));
+
+        exception.expect(OptimisticLockException.class);
+
+        // When
+        dynamoDocumentStoreTemplate.update(stubItem);
+
+        // Then
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void shouldDelete_withItem() {
+        // Given
+        final ItemId itemId = new ItemId(randomId());
+        final StubItem stubItem = generateRandomStubItem(itemId);
+
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(StubItem.class, tableName);
+        final Collection<ItemConfiguration> itemConfigurations = Arrays.asList(itemConfiguration);
+        when(mockDatabaseSchemaHolder.itemConfigurations()).thenReturn(itemConfigurations);
+
+        final Table mockTable = mock(Table.class);
+        when(mockDynamoDBClient.getTable(any(String.class))).thenReturn(mockTable);
+
+        final DynamoDocumentStoreTemplate dynamoDocumentStoreTemplate = new DynamoDocumentStoreTemplate(
+                mockDatabaseSchemaHolder);
+        dynamoDocumentStoreTemplate.initialize(mockAmazonDynamoDbClient);
+
+        // When
+        dynamoDocumentStoreTemplate.delete(stubItem);
+
+        // Then
+        final ArgumentCaptor<DeleteItemSpec> getItemRequestCaptor = ArgumentCaptor.forClass(DeleteItemSpec.class);
+        verify(mockTable).deleteItem(getItemRequestCaptor.capture());
+    }
+
+    private StubItem generateRandomStubItem(final ItemId itemId) {
+        final StubItem item = new StubItem();
+        item.setBooleanProperty(Randoms.randomBoolean());
+        item.setId(itemId.value());
+        item.setStringProperty(Randoms.randomString());
+        item.setStringProperty2(Randoms.randomString());
+        item.setVersion(Randoms.randomLong());
+        final Set<String> stringSet = new HashSet<String>();
+        for (int i = 0; i < Randoms.randomInt(20); i++) {
+            stringSet.add(Randoms.randomString());
+        }
+        item.setStringSetProperty(stringSet);
+        return item;
+    }
+
+}


### PR DESCRIPTION
- Fixed a defect where version numbers were not being initialised and thereafter incremented when creating/updating document rows.
- Updating to add a version check to the update method to ensure correct versioning of data in Dynamo.
- Adding unit test
- Moved version constant to Abstract parent class for use by both children

@clicktravel-robin @clicktravel-basharat @clicktravel-tajinder @clicktravel-steffan - please review and merge if ok and we will do the framework bump.