### PR TITLE
[TRAV-211] changing fetch to use indexes first

### DIFF
--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbDataGenerator.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbDataGenerator.java
@@ -36,9 +36,9 @@ import com.clicktravel.infrastructure.persistence.aws.dynamodb.StubWithRangeItem
 
 public class DynamoDbDataGenerator {
 
-    static final String UNIT_TEST_SCHEMA_NAME = "unittest";
-    static final String STUB_ITEM_TABLE_NAME = "stub_item_" + randomString(10);
-    static final String STUB_ITEM_WITH_RANGE_TABLE_NAME = "stub_item_with_range_" + randomString(10);
+    private final String unitTestSchemaName = "unittest";
+    private final String stubItemTableName = "stub_item_" + randomString(10);
+    private final String stubItemWithRangeTableName = "stub_item_with_range_" + randomString(10);
 
     public final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -50,8 +50,24 @@ public class DynamoDbDataGenerator {
         this.amazonDynamoDbClient = amazonDynamoDbClient;
     }
 
+    String getUnitTestSchemaName() {
+        return unitTestSchemaName;
+    }
+
+    String getStubItemTableName() {
+        return stubItemTableName;
+    }
+
+    String getStubItemWithRangeTableName() {
+        return stubItemWithRangeTableName;
+    }
+
+    Collection<String> getCreatedItemIds() {
+        return createdItemIds;
+    }
+
     void createStubItemTable() throws Exception {
-        final String tableName = UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_TABLE_NAME;
+        final String tableName = unitTestSchemaName + "." + stubItemTableName;
         boolean tableCreated = false;
         try {
             final DescribeTableResult result = amazonDynamoDbClient.describeTable(tableName);
@@ -81,7 +97,7 @@ public class DynamoDbDataGenerator {
     }
 
     void createStubItemWithRangeTable() throws Exception {
-        final String tableName = UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_WITH_RANGE_TABLE_NAME;
+        final String tableName = unitTestSchemaName + "." + stubItemWithRangeTableName;
         boolean tableCreated = false;
         try {
             final DescribeTableResult result = amazonDynamoDbClient.describeTable(tableName);
@@ -122,7 +138,7 @@ public class DynamoDbDataGenerator {
             final Map<String, AttributeValue> key = new HashMap<>();
             key.put("id", new AttributeValue(id));
             final DeleteItemRequest deleteItemRequest = new DeleteItemRequest().withTableName(
-                    UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_TABLE_NAME).withKey(key);
+                    unitTestSchemaName + "." + stubItemTableName).withKey(key);
             try {
                 amazonDynamoDbClient.deleteItem(deleteItemRequest);
             } catch (final Exception e) {
@@ -180,7 +196,7 @@ public class DynamoDbDataGenerator {
         itemMap.put("version", new AttributeValue().withN(String.valueOf(stubItem.getVersion())));
         itemMap.put("discriminator", new AttributeValue().withS("a"));
         final PutItemRequest putItemRequest = new PutItemRequest().withTableName(
-                UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_TABLE_NAME).withItem(itemMap);
+                unitTestSchemaName + "." + stubItemTableName).withItem(itemMap);
         amazonDynamoDbClient.putItem(putItemRequest);
         logger.debug("Created stub item with id: " + stubItem.getId());
         createdItemIds.add(stubItem.getId());
@@ -204,7 +220,7 @@ public class DynamoDbDataGenerator {
         itemMap.put("version", new AttributeValue().withN(String.valueOf(stubItem.getVersion())));
         itemMap.put("discriminator", new AttributeValue().withS("b"));
         final PutItemRequest putItemRequest = new PutItemRequest().withTableName(
-                UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_TABLE_NAME).withItem(itemMap);
+                unitTestSchemaName + "." + stubItemTableName).withItem(itemMap);
         amazonDynamoDbClient.putItem(putItemRequest);
         logger.debug("Created stub item with id: " + stubItem.getId());
         createdItemIds.add(stubItem.getId());
@@ -231,7 +247,7 @@ public class DynamoDbDataGenerator {
         }
         itemMap.put("version", new AttributeValue().withN(String.valueOf(stubItem.getVersion())));
         final PutItemRequest putItemRequest = new PutItemRequest().withTableName(
-                UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_WITH_RANGE_TABLE_NAME).withItem(itemMap);
+                unitTestSchemaName + "." + stubItemWithRangeTableName).withItem(itemMap);
         amazonDynamoDbClient.putItem(putItemRequest);
         logger.debug("Created stub item with id: " + stubItem.getId());
         createdItemIds.add(stubItem.getId());
@@ -258,7 +274,7 @@ public class DynamoDbDataGenerator {
         }
         itemMap.put("version", new AttributeValue().withN(String.valueOf(stubItem.getVersion())));
         final PutItemRequest putItemRequest = new PutItemRequest().withTableName(
-                UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_TABLE_NAME).withItem(itemMap);
+                unitTestSchemaName + "." + stubItemTableName).withItem(itemMap);
         amazonDynamoDbClient.putItem(putItemRequest);
         logger.debug("Created stub item with id: " + stubItem.getId());
         createdItemIds.add(stubItem.getId());
@@ -281,18 +297,18 @@ public class DynamoDbDataGenerator {
         }
         itemMap.put("version", new AttributeValue().withN(String.valueOf(stubItem.getVersion())));
         final PutItemRequest putItemRequest = new PutItemRequest().withTableName(
-                UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_TABLE_NAME).withItem(itemMap);
+                unitTestSchemaName + "." + stubItemTableName).withItem(itemMap);
         amazonDynamoDbClient.putItem(putItemRequest);
         logger.debug("Created stub item with id: " + stubItem.getId());
         createdItemIds.add(stubItem.getId());
     }
 
     public void deleteStubItemTable() {
-        amazonDynamoDbClient.deleteTable(UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_TABLE_NAME);
+        amazonDynamoDbClient.deleteTable(unitTestSchemaName + "." + stubItemTableName);
     }
 
     public void deleteStubItemWithRangeTable() {
-        amazonDynamoDbClient.deleteTable(UNIT_TEST_SCHEMA_NAME + "." + STUB_ITEM_WITH_RANGE_TABLE_NAME);
+        amazonDynamoDbClient.deleteTable(unitTestSchemaName + "." + stubItemWithRangeTableName);
     }
 
 }

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbTemplateIntegrationTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbTemplateIntegrationTest.java
@@ -69,19 +69,18 @@ public class DynamoDbTemplateIntegrationTest {
         final Collection<ItemConfiguration> itemConfigurations = new ArrayList<>();
 
         final ItemConfiguration stubItemConfiguration = new ItemConfiguration(StubItem.class,
-                DynamoDbDataGenerator.STUB_ITEM_TABLE_NAME);
+                dataGenerator.getStubItemTableName());
         final ParentItemConfiguration stubParentItemConfiguration = new ParentItemConfiguration(StubParentItem.class,
-                DynamoDbDataGenerator.STUB_ITEM_TABLE_NAME);
+                dataGenerator.getStubItemTableName());
         final ItemConfiguration stubItemWithRangeConfiguration = new ItemConfiguration(StubWithRangeItem.class,
-                DynamoDbDataGenerator.STUB_ITEM_WITH_RANGE_TABLE_NAME, new CompoundPrimaryKeyDefinition("id",
-                        "supportingId"));
+                dataGenerator.getStubItemWithRangeTableName(), new CompoundPrimaryKeyDefinition("id", "supportingId"));
         itemConfigurations.add(stubItemConfiguration);
         itemConfigurations.add(stubParentItemConfiguration);
         itemConfigurations.add(new VariantItemConfiguration(stubParentItemConfiguration, StubVariantItem.class, "a"));
         itemConfigurations
                 .add(new VariantItemConfiguration(stubParentItemConfiguration, StubVariantTwoItem.class, "b"));
         itemConfigurations.add(stubItemWithRangeConfiguration);
-        databaseSchemaHolder = new DatabaseSchemaHolder(DynamoDbDataGenerator.UNIT_TEST_SCHEMA_NAME, itemConfigurations);
+        databaseSchemaHolder = new DatabaseSchemaHolder(dataGenerator.getUnitTestSchemaName(), itemConfigurations);
     }
 
     @After
@@ -527,8 +526,8 @@ public class DynamoDbTemplateIntegrationTest {
         // Then
         final Map<String, AttributeValue> key = new HashMap<>();
         key.put("id", new AttributeValue(createdItem.getId()));
-        final GetItemResult result = amazonDynamoDbClient.getItem(DynamoDbDataGenerator.UNIT_TEST_SCHEMA_NAME + "."
-                + DynamoDbDataGenerator.STUB_ITEM_TABLE_NAME, key);
+        final GetItemResult result = amazonDynamoDbClient.getItem(dataGenerator.getUnitTestSchemaName() + "."
+                + dataGenerator.getStubItemTableName(), key);
         assertNull(result.getItem());
     }
 
@@ -546,8 +545,8 @@ public class DynamoDbTemplateIntegrationTest {
         final Map<String, AttributeValue> key = new HashMap<>();
         key.put("id", new AttributeValue(createdItem.getId()));
         key.put("supportingId", new AttributeValue(createdItem.getSupportingId()));
-        final GetItemResult result = amazonDynamoDbClient.getItem(DynamoDbDataGenerator.UNIT_TEST_SCHEMA_NAME + "."
-                + DynamoDbDataGenerator.STUB_ITEM_WITH_RANGE_TABLE_NAME, key);
+        final GetItemResult result = amazonDynamoDbClient.getItem(dataGenerator.getUnitTestSchemaName() + "."
+                + dataGenerator.getStubItemWithRangeTableName(), key);
         assertNull(result.getItem());
     }
 
@@ -648,36 +647,6 @@ public class DynamoDbTemplateIntegrationTest {
         assertTrue(returnedItemSet.equals(items));
         for (final StubParentItem returnedItem : returnedItems) {
             assertTrue(returnedItem instanceof StubVariantItem);
-        }
-    }
-
-    @Test
-    public void shouldFetch_withKeySetQueryFromDocumentStoreTemplate() {
-        // Given
-        // create 50 large objects to trigger multiple fetches
-        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
-        dynamoDbTemplate.initialize(amazonDynamoDbClient);
-        final KeySetQuery q = new KeySetQuery(new ArrayList<ItemId>());
-        final List<String> savedKeys = new ArrayList<String>();
-        final int itemsToCreate = 50;
-        for (int i = 0; i < itemsToCreate; i++) {
-            final StubItem item = new StubItem();
-            item.setId(Randoms.randomString());
-            final char[] chars = new char[100000];
-            Arrays.fill(chars, 'X');
-            item.setStringProperty(new String(chars));
-            dynamoDbTemplate.create(item);
-            savedKeys.add(item.getId());
-            q.itemIds().add(new ItemId(item.getId()));
-        }
-
-        // When
-        final Collection<StubItem> allItems = dynamoDbTemplate.fetch(q, StubItem.class);
-
-        // Then
-        assertEquals(itemsToCreate, allItems.size());
-        for (final StubItem i : allItems) {
-            assertTrue(savedKeys.contains(i.getId()));
         }
     }
 

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDocumentStoreTemplateIntegrationTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDocumentStoreTemplateIntegrationTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.infrastructure.persistence.aws.dynamodb.integration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.*;
+
+import org.junit.*;
+import org.junit.experimental.categories.Category;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.clicktravel.cheddar.infrastructure.persistence.database.ItemId;
+import com.clicktravel.cheddar.infrastructure.persistence.database.configuration.CompoundPrimaryKeyDefinition;
+import com.clicktravel.cheddar.infrastructure.persistence.database.configuration.DatabaseSchemaHolder;
+import com.clicktravel.cheddar.infrastructure.persistence.database.configuration.ItemConfiguration;
+import com.clicktravel.cheddar.infrastructure.persistence.database.exception.NonExistentItemException;
+import com.clicktravel.cheddar.infrastructure.persistence.database.query.*;
+import com.clicktravel.common.random.Randoms;
+import com.clicktravel.infrastructure.integration.aws.AwsIntegration;
+import com.clicktravel.infrastructure.persistence.aws.dynamodb.DynamoDocumentStoreTemplate;
+import com.clicktravel.infrastructure.persistence.aws.dynamodb.StubItem;
+import com.clicktravel.infrastructure.persistence.aws.dynamodb.StubWithRangeItem;
+
+@Category({ AwsIntegration.class })
+public class DynamoDocumentStoreTemplateIntegrationTest {
+
+    private static DynamoDbDataGenerator dataGenerator;
+    private final Collection<String> createdItemIds = new ArrayList<>();
+    private static AmazonDynamoDBClient amazonDynamoDbClient;
+    private DatabaseSchemaHolder databaseSchemaHolder;
+
+    @BeforeClass
+    public static void createTables() throws Exception {
+        amazonDynamoDbClient = new AmazonDynamoDBClient(new BasicAWSCredentials(AwsIntegration.getAccessKeyId(),
+                AwsIntegration.getSecretKeyId()));
+        amazonDynamoDbClient.setEndpoint(AwsIntegration.getDynamoDbEndpoint());
+        dataGenerator = new DynamoDbDataGenerator(amazonDynamoDbClient);
+
+        dataGenerator.createStubItemTable();
+        dataGenerator.createStubItemWithRangeTable();
+    }
+
+    @Before
+    public void init() throws Exception {
+        createdItemIds.clear();
+        dataGenerator.getCreatedItemIds().clear();
+        final Collection<ItemConfiguration> itemConfigurations = new ArrayList<>();
+
+        final ItemConfiguration stubItemConfiguration = new ItemConfiguration(StubItem.class,
+                dataGenerator.getStubItemTableName());
+        final ItemConfiguration stubItemWithRangeConfiguration = new ItemConfiguration(StubWithRangeItem.class,
+                dataGenerator.getStubItemWithRangeTableName(), new CompoundPrimaryKeyDefinition("id", "supportingId"));
+        itemConfigurations.add(stubItemConfiguration);
+        itemConfigurations.add(stubItemWithRangeConfiguration);
+        databaseSchemaHolder = new DatabaseSchemaHolder(dataGenerator.getUnitTestSchemaName(), itemConfigurations);
+    }
+
+    @After
+    public void tearDown() {
+        dataGenerator.getCreatedItemIds().addAll(createdItemIds);
+        dataGenerator.deletedCreatedItems();
+    }
+
+    @AfterClass
+    public static void deleteTables() {
+        dataGenerator.deleteStubItemTable();
+        dataGenerator.deleteStubItemWithRangeTable();
+    }
+
+    @Test
+    public void shouldCreateNewItem_withItem() {
+        // Given
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        final StubItem stubItem = dataGenerator.randomStubItem();
+        stubItem.setVersion(null);
+
+        // When
+        final StubItem item = dynamoDbTemplate.create(stubItem);
+
+        // Then
+        createdItemIds.add(item.getId());
+        assertEquals(new Long(1), item.getVersion());
+        assertEquals(stubItem.getId(), item.getId());
+        assertEquals(stubItem.getStringProperty(), item.getStringProperty());
+        assertEquals(stubItem.getStringProperty2(), item.getStringProperty2());
+        assertEquals(stubItem.getStringSetProperty(), item.getStringSetProperty());
+    }
+
+    @Test
+    public void shouldReadItem_withItem() {
+        // Given
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        final StubItem stubItem = dataGenerator.randomStubItem();
+        stubItem.setVersion(null);
+        dynamoDbTemplate.create(stubItem);
+
+        // When
+        final StubItem item = dynamoDbTemplate.read(new ItemId(stubItem.getId()), StubItem.class);
+
+        // Then
+        createdItemIds.add(item.getId());
+        assertEquals(new Long(1), item.getVersion());
+        assertEquals(stubItem.getId(), item.getId());
+        assertEquals(stubItem.getStringProperty(), item.getStringProperty());
+        assertEquals(stubItem.getStringProperty2(), item.getStringProperty2());
+        assertEquals(stubItem.getStringSetProperty(), item.getStringSetProperty());
+    }
+
+    @Test
+    public void shouldUpdateItem_withItem() {
+        // Given
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        StubItem stubItem = dataGenerator.randomStubItem();
+        stubItem.setVersion(null);
+        stubItem = dynamoDbTemplate.create(stubItem);
+        stubItem.setStringProperty(Randoms.randomString());
+        stubItem.setStringProperty2(Randoms.randomString());
+        final Set<String> propSet = new HashSet<String>();
+        for (int i = 0; i < Randoms.randomInt(10); i++) {
+            propSet.add(Randoms.randomString());
+        }
+        stubItem.setStringSetProperty(propSet);
+
+        // When
+        final StubItem item = dynamoDbTemplate.update(stubItem);
+
+        // Then
+        createdItemIds.add(item.getId());
+        assertEquals(new Long(2), item.getVersion());
+        assertEquals(stubItem.getId(), item.getId());
+        assertEquals(stubItem.getStringProperty(), item.getStringProperty());
+        assertEquals(stubItem.getStringProperty2(), item.getStringProperty2());
+        assertEquals(stubItem.getStringSetProperty(), item.getStringSetProperty());
+    }
+
+    @Test
+    public void shouldDeleteItem_withItem() {
+        // Given
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        StubItem stubItem = dataGenerator.randomStubItem();
+        stubItem.setVersion(null);
+        stubItem = dynamoDbTemplate.create(stubItem);
+
+        // When
+        dynamoDbTemplate.delete(stubItem);
+
+        // Then
+        NonExistentItemException expectedException = null;
+        try {
+            dynamoDbTemplate.read(new ItemId(stubItem.getId()), StubItem.class);
+        } catch (final NonExistentItemException e) {
+            expectedException = e;
+        }
+        assertNotNull(expectedException);
+    }
+
+    @Test
+    public void shouldFetch_withEqualsAttributeQuery() {
+        // Given
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        final List<StubItem> expectedMatchingItems = new ArrayList<StubItem>();
+        final String fetchCriteriaValue = Randoms.randomString(10);
+        final Query query = new AttributeQuery("stringProperty", new Condition(Operators.EQUALS, fetchCriteriaValue));
+        for (int i = 0; i < 20; i++) {
+            final StubItem item = dataGenerator.randomStubItem();
+            if (Randoms.randomBoolean() || item.getStringProperty().equals(fetchCriteriaValue)) {
+                item.setStringProperty(fetchCriteriaValue);
+                expectedMatchingItems.add(item);
+            }
+            dynamoDbTemplate.create(item);
+            createdItemIds.add(item.getId());
+        }
+
+        // When
+        final Collection<StubItem> allItems = dynamoDbTemplate.fetch(query, StubItem.class);
+
+        // Then
+        assertEquals(expectedMatchingItems.size(), allItems.size());
+        assertTrue(allItems.containsAll(expectedMatchingItems));
+    }
+
+    @Test
+    public void shouldFetch_withGreaterThanOrEqualsAttributeQuery() {
+        // Given
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        final List<StubItem> expectedMatchingItems = new ArrayList<StubItem>();
+        final Long criteriaValue = Long.valueOf(2);
+        final Query query = new AttributeQuery("version", new Condition(Operators.GREATER_THAN_OR_EQUALS,
+                criteriaValue.toString()));
+        for (int i = 0; i < 20; i++) {
+            final StubItem item = dataGenerator.randomStubItem();
+            if (Randoms.randomBoolean()) {
+                expectedMatchingItems.add(item);
+            }
+            dynamoDbTemplate.create(item); // v1 objects
+            createdItemIds.add(item.getId());
+        }
+        for (final StubItem matchingItem : expectedMatchingItems) {
+            matchingItem.setStringProperty(Randoms.randomString(10));
+            dynamoDbTemplate.update(matchingItem);// v2 objects
+            if (Randoms.randomBoolean()) {
+                matchingItem.setStringProperty(Randoms.randomString(10));
+                dynamoDbTemplate.update(matchingItem);// v3 objects
+            }
+        }
+
+        // When
+        final Collection<StubItem> allItems = dynamoDbTemplate.fetch(query, StubItem.class);
+
+        // Then
+        assertEquals(expectedMatchingItems.size(), allItems.size());
+        assertTrue(allItems.containsAll(expectedMatchingItems));
+    }
+
+    @Test
+    public void shouldFetch_withLessThanOrEqualsAttributeQuery() {
+        // Given
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        final List<StubItem> expectedMatchingItems = new ArrayList<StubItem>();
+        final Long criteriaLowValue = Long.valueOf(2);
+        final Query query = new AttributeQuery("version", new Condition(Operators.LESS_THAN_OR_EQUALS,
+                criteriaLowValue.toString()));
+        for (int i = 0; i < 20; i++) {
+            final StubItem item = dataGenerator.randomStubItem();
+            expectedMatchingItems.add(item);
+            dynamoDbTemplate.create(item);// v1 objects
+            createdItemIds.add(item.getId());
+        }
+        final StubItem[] matchingItemsArray = expectedMatchingItems.toArray(new StubItem[expectedMatchingItems.size()]);
+        for (final StubItem matchingItem : matchingItemsArray) {
+            if (Randoms.randomBoolean()) {
+                matchingItem.setStringProperty(Randoms.randomString(10));
+                dynamoDbTemplate.update(matchingItem);// v2 objects
+                if (Randoms.randomBoolean()) {
+                    matchingItem.setStringProperty(Randoms.randomString(10));
+                    dynamoDbTemplate.update(matchingItem);// v3 objects, not expected
+                    expectedMatchingItems.remove(matchingItem);
+                }
+            }
+
+        }
+
+        // When
+        final Collection<StubItem> allItems = dynamoDbTemplate.fetch(query, StubItem.class);
+
+        // Then
+        assertEquals(expectedMatchingItems.size(), allItems.size());
+        assertTrue(allItems.containsAll(expectedMatchingItems));
+
+    }
+
+    @Test
+    public void shouldFetchUnique_withEqualsAttributeQuery() {
+        // Given
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        StubItem expectedMatchingItem = null;
+        final String fetchCriteriaValue = Randoms.randomString(10);
+        final Query query = new AttributeQuery("stringProperty", new Condition(Operators.EQUALS, fetchCriteriaValue));
+        final int itemCount = 20;
+        final int randomIndex = Randoms.randomInt(itemCount);
+        for (int i = 0; i < itemCount; i++) {
+            final StubItem item = dataGenerator.randomStubItem();
+            if (i == randomIndex) {
+                item.setStringProperty(fetchCriteriaValue);
+                expectedMatchingItem = item;
+            } else {
+                while (item.getStringProperty().equals(fetchCriteriaValue)) {// ensure value unique
+                    item.setStringProperty(Randoms.randomString(10));
+                }
+            }
+            dynamoDbTemplate.create(item);
+            createdItemIds.add(item.getId());
+        }
+
+        // When
+        final StubItem returnedItem = dynamoDbTemplate.fetchUnique(query, StubItem.class);
+
+        // Then
+        assertEquals(expectedMatchingItem, returnedItem);
+    }
+
+    @Test
+    public void shouldFetch_withKeySetQueryFromDocumentStoreTemplate() {
+        // Given
+        // create 50 large objects to trigger multiple fetches
+        final DynamoDocumentStoreTemplate dynamoDbTemplate = new DynamoDocumentStoreTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+        final KeySetQuery q = new KeySetQuery(new ArrayList<ItemId>());
+        final List<String> savedKeys = new ArrayList<String>();
+        final int itemsToCreate = 50;
+        for (int i = 0; i < itemsToCreate; i++) {
+            final StubItem item = new StubItem();
+            item.setId(Randoms.randomString());
+            final char[] chars = new char[100000];
+            Arrays.fill(chars, 'X');
+            item.setStringProperty(new String(chars));
+            dynamoDbTemplate.create(item);
+            savedKeys.add(item.getId());
+            q.itemIds().add(new ItemId(item.getId()));
+        }
+
+        // When
+        final Collection<StubItem> allItems = dynamoDbTemplate.fetch(q, StubItem.class);
+
+        // Then
+        assertEquals(itemsToCreate, allItems.size());
+        for (final StubItem i : allItems) {
+            assertTrue(savedKeys.contains(i.getId()));
+        }
+    }
+}


### PR DESCRIPTION
@clicktravel-tajinder @clicktravel-robin @clicktravel-basharat @clicktravel-steffan - noticed a couple of issues in the document template which are fixed by this pull request, please review and merge when happy.

1. Updating the fetch method for DynamoDocumentStoreTemplate so that if the field is indexed the index will be queried rather than a table scan being performed.

2. Fixed another bug with using comparators on numeric fields.

3. Added an integration test resulting in some refactoring of DynamoDbTemplateIntegrationTest to take out the DynamoDocumentStoreTemplate test and DynamoDbDataGenerator to be usable by both integration tests.