### PR TITLE
[FC-91] Updated Cheddar to support Agents

### DIFF
--- a/cheddar/cheddar-application/src/main/java/com/clicktravel/cheddar/application/security/SecurityChecker.java
+++ b/cheddar/cheddar-application/src/main/java/com/clicktravel/cheddar/application/security/SecurityChecker.java
@@ -16,6 +16,7 @@
  */
 package com.clicktravel.cheddar.application.security;
 
+import com.clicktravel.cheddar.request.context.SecurityContext;
 import com.clicktravel.cheddar.request.context.SecurityContextHolder;
 
 public class SecurityChecker {
@@ -26,7 +27,8 @@ public class SecurityChecker {
      * @param principal
      */
     public static void checkPrincipal(final String principal) {
-        final String currentPrincipal = SecurityContextHolder.getPrincipal();
+        final SecurityContext securityContext = SecurityContextHolder.get();
+        final String currentPrincipal = securityContext == null ? null : securityContext.principal();
         if (currentPrincipal == null) {
             throw new CredentialsMissingException();
         }
@@ -39,7 +41,7 @@ public class SecurityChecker {
      * Checks that there is a principal in the current context i.e. a user is authenticated
      */
     public static void checkAuthenticated() {
-        if (SecurityContextHolder.getPrincipal() == null) {
+        if (SecurityContextHolder.get() == null) {
             throw new CredentialsMissingException();
         }
     }

--- a/cheddar/cheddar-application/src/test/java/com/clicktravel/cheddar/application/security/SecurityCheckerTest.java
+++ b/cheddar/cheddar-application/src/test/java/com/clicktravel/cheddar/application/security/SecurityCheckerTest.java
@@ -19,6 +19,7 @@ package com.clicktravel.cheddar.application.security;
 import static com.clicktravel.common.random.Randoms.randomId;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -27,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.clicktravel.cheddar.request.context.SecurityContext;
 import com.clicktravel.cheddar.request.context.SecurityContextHolder;
 
 @RunWith(PowerMockRunner.class)
@@ -37,8 +39,10 @@ public class SecurityCheckerTest {
     public void shouldNotPassPrincipalCheck_withNullCheckPrincipal() {
         // Given
         final String principal = randomId();
+        final SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        when(mockSecurityContext.principal()).thenReturn(principal);
         mockStatic(SecurityContextHolder.class);
-        when(SecurityContextHolder.getPrincipal()).thenReturn(principal);
+        when(SecurityContextHolder.get()).thenReturn(mockSecurityContext);
 
         // When
         SecurityConstraintViolationException expectedException = null;
@@ -56,7 +60,7 @@ public class SecurityCheckerTest {
     public void shouldNotPassPrincipalCheck_withNullStoredPrincipal() {
         // Given
         mockStatic(SecurityContextHolder.class);
-        when(SecurityContextHolder.getPrincipal()).thenReturn(null);
+        when(SecurityContextHolder.get()).thenReturn(null);
         final String principal = randomId();
 
         // When
@@ -75,8 +79,10 @@ public class SecurityCheckerTest {
     public void shouldPassAutheticatedCheck_withPrincipal() {
         // Given
         final String principal = randomId();
+        final SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        when(mockSecurityContext.principal()).thenReturn(principal);
         mockStatic(SecurityContextHolder.class);
-        when(SecurityContextHolder.getPrincipal()).thenReturn(principal);
+        when(SecurityContextHolder.get()).thenReturn(mockSecurityContext);
 
         // When
         CredentialsMissingException unexpectedException = null;
@@ -94,7 +100,7 @@ public class SecurityCheckerTest {
     public void shouldNotPassAutheticatedCheck_withNoPrincipal() {
         // Given
         mockStatic(SecurityContextHolder.class);
-        when(SecurityContextHolder.getPrincipal()).thenReturn(null);
+        when(SecurityContextHolder.get()).thenReturn(null);
 
         // When
         CredentialsMissingException expectedException = null;

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AgentSecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AgentSecurityContext.java
@@ -17,7 +17,8 @@
 package com.clicktravel.cheddar.request.context;
 
 /**
- * Obtains the currently authenticated principal's user id when an agent acts on behalf of the authenticated user.
+ * Identifies an effective principal as the principal in the security context, and a supporting agent principal. This is
+ * used when an agent acts on behalf of (i.e. impersonates) a supported user.
  *
  * @see BasicSecurityContext
  */

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AgentSecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AgentSecurityContext.java
@@ -16,6 +16,11 @@
  */
 package com.clicktravel.cheddar.request.context;
 
+/**
+ * Obtains the currently authenticated principal's user id when an agent acts on behalf of the authenticated user.
+ *
+ * @see BasicSecurityContext
+ */
 public class AgentSecurityContext implements SecurityContext {
 
     private final String effectivePrincipal;
@@ -31,6 +36,10 @@ public class AgentSecurityContext implements SecurityContext {
         return effectivePrincipal;
     }
 
+    /**
+     * Returns the agent's user id who is acting on behalf of the principal
+     * @return
+     */
     public String agent() {
         return agent;
     }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AgentSecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/AgentSecurityContext.java
@@ -16,23 +16,23 @@
  */
 package com.clicktravel.cheddar.request.context;
 
-/**
- * Retains the security context for the scope of a request.
- */
-public class SecurityContextHolder {
+public class AgentSecurityContext implements SecurityContext {
 
-    private final static ThreadLocal<SecurityContext> SECURITY_CONTEXT = new ThreadLocal<SecurityContext>() {
-    };
+    private final String effectivePrincipal;
+    private final String agent;
 
-    public static void set(final SecurityContext securityContext) {
-        SECURITY_CONTEXT.set(securityContext);
+    public AgentSecurityContext(final String effectivePrincipal, final String agent) {
+        this.effectivePrincipal = effectivePrincipal;
+        this.agent = agent;
     }
 
-    public static SecurityContext get() {
-        return SECURITY_CONTEXT.get();
+    @Override
+    public String principal() {
+        return effectivePrincipal;
     }
 
-    public static void clear() {
-        SECURITY_CONTEXT.remove();
+    public String agent() {
+        return agent;
     }
+
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/BasicSecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/BasicSecurityContext.java
@@ -16,6 +16,11 @@
  */
 package com.clicktravel.cheddar.request.context;
 
+/**
+ * Obtains the currently authenticated principal's user id when the principal acts on their own behalf without an agent.
+ *
+ * @see AgentSecurityContext
+ */
 public class BasicSecurityContext implements SecurityContext {
 
     private final String principal;

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/BasicSecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/BasicSecurityContext.java
@@ -16,23 +16,17 @@
  */
 package com.clicktravel.cheddar.request.context;
 
-/**
- * Retains the security context for the scope of a request.
- */
-public class SecurityContextHolder {
+public class BasicSecurityContext implements SecurityContext {
 
-    private final static ThreadLocal<SecurityContext> SECURITY_CONTEXT = new ThreadLocal<SecurityContext>() {
-    };
+    private final String principal;
 
-    public static void set(final SecurityContext securityContext) {
-        SECURITY_CONTEXT.set(securityContext);
+    public BasicSecurityContext(final String principal) {
+        this.principal = principal;
     }
 
-    public static SecurityContext get() {
-        return SECURITY_CONTEXT.get();
+    @Override
+    public String principal() {
+        return principal;
     }
 
-    public static void clear() {
-        SECURITY_CONTEXT.remove();
-    }
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/BasicSecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/BasicSecurityContext.java
@@ -17,7 +17,8 @@
 package com.clicktravel.cheddar.request.context;
 
 /**
- * Obtains the currently authenticated principal's user id when the principal acts on their own behalf without an agent.
+ * Identifies the currently authenticated user as the principal in the security context. This is used when the user acts
+ * on their own behalf without an agent.
  *
  * @see AgentSecurityContext
  */

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
@@ -16,6 +16,11 @@
  */
 package com.clicktravel.cheddar.request.context;
 
+/**
+ * Interface defining the minimum security information associated with the current thread of execution.
+ *
+ * @see {@link BasicSecurityContext} and {@link AgentSecurityContext}
+ */
 public interface SecurityContext {
 
     String principal();

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
@@ -23,6 +23,10 @@ package com.clicktravel.cheddar.request.context;
  */
 public interface SecurityContext {
 
+    /**
+     * @return The user ID of the principal in the security context. Domain actions (final commands or queries) are
+     *         performed 'as' this user. This is the actor which any authorisation checks should be performed against.
+     */
     String principal();
 
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
@@ -16,23 +16,8 @@
  */
 package com.clicktravel.cheddar.request.context;
 
-/**
- * Retains the security context for the scope of a request.
- */
-public class SecurityContextHolder {
+public interface SecurityContext {
 
-    private final static ThreadLocal<SecurityContext> SECURITY_CONTEXT = new ThreadLocal<SecurityContext>() {
-    };
+    String principal();
 
-    public static void set(final SecurityContext securityContext) {
-        SECURITY_CONTEXT.set(securityContext);
-    }
-
-    public static SecurityContext get() {
-        return SECURITY_CONTEXT.get();
-    }
-
-    public static void clear() {
-        SECURITY_CONTEXT.remove();
-    }
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContext.java
@@ -24,8 +24,8 @@ package com.clicktravel.cheddar.request.context;
 public interface SecurityContext {
 
     /**
-     * @return The user ID of the principal in the security context. Domain actions (final commands or queries) are
-     *         performed 'as' this user. This is the actor which any authorisation checks should be performed against.
+     * @return The user ID of the principal in the security context. Domain actions (commands or queries) are performed
+     *         'as' this user. This is the actor which any authorisation checks should be performed against.
      */
     String principal();
 

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContextHolder.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContextHolder.java
@@ -59,4 +59,13 @@ public class SecurityContextHolder {
             set(new BasicSecurityContext(principal));
         }
     }
+
+    /**
+     * @deprecated Use SecurityContextHolder.clear()
+     */
+    @Deprecated
+    public static void clearPrincipal() {
+        clear();
+    }
+
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContextHolder.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContextHolder.java
@@ -35,4 +35,28 @@ public class SecurityContextHolder {
     public static void clear() {
         SECURITY_CONTEXT.remove();
     }
+
+    /**
+     * @deprecated Use SecurityContextHolder.get().principal();
+     */
+    @Deprecated
+    public String getPrincipal() {
+        final SecurityContext securityContext = get();
+        if (securityContext == null) {
+            return null;
+        }
+        return securityContext.principal();
+    }
+
+    /**
+     * @deprecated Use SecurityContextHolder.set(SecurityContext)
+     */
+    @Deprecated
+    public void setPrincipal(final String principal) {
+        if (principal == null) {
+            clear();
+        } else {
+            set(new BasicSecurityContext(principal));
+        }
+    }
 }

--- a/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContextHolder.java
+++ b/cheddar/cheddar-context/src/main/java/com/clicktravel/cheddar/request/context/SecurityContextHolder.java
@@ -40,7 +40,7 @@ public class SecurityContextHolder {
      * @deprecated Use SecurityContextHolder.get().principal();
      */
     @Deprecated
-    public String getPrincipal() {
+    public static String getPrincipal() {
         final SecurityContext securityContext = get();
         if (securityContext == null) {
             return null;
@@ -52,7 +52,7 @@ public class SecurityContextHolder {
      * @deprecated Use SecurityContextHolder.set(SecurityContext)
      */
     @Deprecated
-    public void setPrincipal(final String principal) {
+    public static void setPrincipal(final String principal) {
         if (principal == null) {
             clear();
         } else {

--- a/cheddar/cheddar-context/src/test/java/com/clicktravel/cheddar/request/context/AgentSecurityContextTest.java
+++ b/cheddar/cheddar-context/src/test/java/com/clicktravel/cheddar/request/context/AgentSecurityContextTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.request.context;
+
+import static com.clicktravel.common.random.Randoms.randomId;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class AgentSecurityContextTest {
+
+    @Test
+    public void shouldCreateAgentSecurityContext_withEffectivePrincipalAndAgent() {
+        // Given
+        final String effectivePrincipal = randomId();
+        final String agent = randomId();
+
+        // When
+        final AgentSecurityContext securityContext = new AgentSecurityContext(effectivePrincipal, agent);
+
+        // Then
+        assertThat(securityContext.principal(), is(effectivePrincipal));
+        assertThat(securityContext.agent(), is(agent));
+    }
+
+}

--- a/cheddar/cheddar-context/src/test/java/com/clicktravel/cheddar/request/context/BasicSecurityContextTest.java
+++ b/cheddar/cheddar-context/src/test/java/com/clicktravel/cheddar/request/context/BasicSecurityContextTest.java
@@ -16,23 +16,24 @@
  */
 package com.clicktravel.cheddar.request.context;
 
-/**
- * Retains the security context for the scope of a request.
- */
-public class SecurityContextHolder {
+import static com.clicktravel.common.random.Randoms.randomId;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
-    private final static ThreadLocal<SecurityContext> SECURITY_CONTEXT = new ThreadLocal<SecurityContext>() {
-    };
+import org.junit.Test;
 
-    public static void set(final SecurityContext securityContext) {
-        SECURITY_CONTEXT.set(securityContext);
+public class BasicSecurityContextTest {
+
+    @Test
+    public void shouldCreateSecurityContext_withPrincipal() {
+        // Given
+        final String principal = randomId();
+
+        // When
+        final BasicSecurityContext securityContext = new BasicSecurityContext(principal);
+
+        // Then
+        assertThat(securityContext.principal(), is(principal));
     }
 
-    public static SecurityContext get() {
-        return SECURITY_CONTEXT.get();
-    }
-
-    public static void clear() {
-        SECURITY_CONTEXT.remove();
-    }
 }

--- a/cheddar/cheddar-context/src/test/java/com/clicktravel/cheddar/request/context/SecurityContextHolderTest.java
+++ b/cheddar/cheddar-context/src/test/java/com/clicktravel/cheddar/request/context/SecurityContextHolderTest.java
@@ -16,63 +16,61 @@
  */
 package com.clicktravel.cheddar.request.context;
 
-import static com.clicktravel.common.random.Randoms.randomId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
-
-import com.clicktravel.cheddar.request.context.SecurityContextHolder;
 
 public class SecurityContextHolderTest {
 
     @Test
     public void shouldSetSecurityContext_withOneThread() {
         // Given
-        final String principal = randomId();
+        final SecurityContext securityContext = mock(SecurityContext.class);
 
         // When
-        SecurityContextHolder.setPrincipal(principal);
-        final String resultPrincipal = SecurityContextHolder.getPrincipal();
+        SecurityContextHolder.set(securityContext);
+        final SecurityContext resultSecurityContext = SecurityContextHolder.get();
 
         // Then
-        assertNotNull(resultPrincipal);
-        assertEquals(principal, resultPrincipal);
+        assertNotNull(resultSecurityContext);
+        assertEquals(securityContext, resultSecurityContext);
     }
 
     @Test
     public void shouldSetSecurityContext_withTwoThreads() throws Exception {
         // Given
-        final String principal1 = randomId();
-        final String principal2 = randomId();
+        final SecurityContext securityContext1 = mock(SecurityContext.class);
+        final SecurityContext securityContext2 = mock(SecurityContext.class);
 
         // When
-        final ContextTestThread thread1 = new ContextTestThread(principal1);
-        final ContextTestThread thread2 = new ContextTestThread(principal2);
+        final ContextTestThread thread1 = new ContextTestThread(securityContext1);
+        final ContextTestThread thread2 = new ContextTestThread(securityContext2);
         thread1.start();
         thread2.start();
         thread2.carryOn();
         Thread.sleep(1000);
         thread1.carryOn();
         Thread.sleep(1000);
-        final String resultPrincipal1 = thread1.getResultPrincipal();
-        final String resultPrincipal2 = thread2.getResultPrincipal();
+        final SecurityContext resultSecurityContext1 = thread1.getResultSecurityContext();
+        final SecurityContext resultSecurityContext2 = thread2.getResultSecurityContext();
 
         // Then
-        assertNotNull(resultPrincipal1);
-        assertEquals(principal1, resultPrincipal1);
-        assertNotNull(resultPrincipal2);
-        assertEquals(principal2, resultPrincipal2);
+        assertNotNull(resultSecurityContext1);
+        assertEquals(securityContext1, resultSecurityContext1);
+        assertNotNull(resultSecurityContext2);
+        assertEquals(securityContext2, resultSecurityContext2);
     }
 
     private static class ContextTestThread extends Thread {
 
-        private final String principal;
-        private String resultPrincipal;
+        private final SecurityContext securityContext;
+        private SecurityContext resultSecurityContext;
         private boolean notRunning = true;
 
-        public ContextTestThread(final String principal) {
-            this.principal = principal;
+        public ContextTestThread(final SecurityContext securityContext) {
+            this.securityContext = securityContext;
         }
 
         public void carryOn() {
@@ -81,7 +79,7 @@ public class SecurityContextHolderTest {
 
         @Override
         public void run() {
-            SecurityContextHolder.setPrincipal(principal);
+            SecurityContextHolder.set(securityContext);
             while (notRunning) {
                 try {
                     // Give the other thread time to process
@@ -89,11 +87,11 @@ public class SecurityContextHolderTest {
                 } catch (final InterruptedException e) {
                 }
             }
-            resultPrincipal = SecurityContextHolder.getPrincipal();
+            resultSecurityContext = SecurityContextHolder.get();
         }
 
-        public String getResultPrincipal() {
-            return resultPrincipal;
+        public SecurityContext getResultSecurityContext() {
+            return resultSecurityContext;
         }
 
     }

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityRequestFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityRequestFilter.java
@@ -38,6 +38,7 @@ import com.clicktravel.cheddar.request.context.SecurityContextHolder;
 @Priority(Priorities.AUTHENTICATION)
 public class ContainerSecurityRequestFilter implements ContainerRequestFilter {
 
+    private static final String PROXY_AUTHORIZATION = "Proxy-Authorization";
     private static final String PRINCIPAL_HEADER_VALUE_PREFIX = "clickplatform";
     private static final String AGENT_HEADER_VALUE_PREFIX = "clickplatform-agent";
 
@@ -52,7 +53,15 @@ public class ContainerSecurityRequestFilter implements ContainerRequestFilter {
                 if (headerValueParts.length == 2) {
                     if (PRINCIPAL_HEADER_VALUE_PREFIX.equals(headerValueParts[0])) {
                         principal = headerValueParts[1];
-                    } else if (AGENT_HEADER_VALUE_PREFIX.equals(headerValueParts[0])) {
+                    }
+                }
+            }
+        }
+        if (headersMap.containsKey(PROXY_AUTHORIZATION)) {
+            for (final String headerValue : headersMap.get(PROXY_AUTHORIZATION)) {
+                final String[] headerValueParts = headerValue.split(" ");
+                if (headerValueParts.length == 2) {
+                    if (AGENT_HEADER_VALUE_PREFIX.equals(headerValueParts[0])) {
                         agent = headerValueParts[1];
                     }
                 }

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityResponseFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityResponseFilter.java
@@ -34,6 +34,6 @@ public class ContainerSecurityResponseFilter implements ContainerResponseFilter 
     @Override
     public void filter(final ContainerRequestContext requestContext, final ContainerResponseContext responseContext)
             throws IOException {
-        SecurityContextHolder.clearPrincipal();
+        SecurityContextHolder.clear();
     }
 }

--- a/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityRequestFilterTest.java
+++ b/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityRequestFilterTest.java
@@ -77,7 +77,7 @@ public class ContainerSecurityRequestFilterTest {
         final ContainerRequestContext mockContainerRequestContext = mock(ContainerRequestContext.class);
         final MultivaluedMap<String, String> headersMap = new MultivaluedHashMap<>();
         headersMap.add(HttpHeaders.AUTHORIZATION, PRINCIPAL_HEADER_VALUE_PREFIX + " " + principal);
-        headersMap.add(HttpHeaders.AUTHORIZATION, AGENT_HEADER_VALUE_PREFIX + " " + agent);
+        headersMap.add("Proxy-Authorization", AGENT_HEADER_VALUE_PREFIX + " " + agent);
         when(mockContainerRequestContext.getHeaders()).thenReturn(headersMap);
         final ContainerSecurityRequestFilter containerSecurityRequestFilter = new ContainerSecurityRequestFilter();
 

--- a/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityRequestFilterTest.java
+++ b/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityRequestFilterTest.java
@@ -16,7 +16,8 @@
  */
 package com.clicktravel.cheddar.server.http.filter.security;
 
-import static org.mockito.Mockito.never;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
@@ -29,9 +30,12 @@ import javax.ws.rs.core.MultivaluedMap;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.clicktravel.cheddar.request.context.AgentSecurityContext;
+import com.clicktravel.cheddar.request.context.BasicSecurityContext;
 import com.clicktravel.cheddar.request.context.SecurityContextHolder;
 import com.clicktravel.common.random.Randoms;
 
@@ -39,16 +43,64 @@ import com.clicktravel.common.random.Randoms;
 @PrepareForTest({ SecurityContextHolder.class })
 public class ContainerSecurityRequestFilterTest {
 
-    private static final String AUTHORIZATION_HEADER_VALUE_PREFIX = "clickplatform ";
+    private static final String PRINCIPAL_HEADER_VALUE_PREFIX = "clickplatform";
+    private static final String AGENT_HEADER_VALUE_PREFIX = "clickplatform-agent";
 
     @Test
-    public void shouldSetPrincipal_withClickPlatformAuthorizationHeader() throws Exception {
+    public void shouldSetPrincipal_withPrincipalHeader() throws Exception {
         // Given
         mockStatic(SecurityContextHolder.class);
         final String principal = Randoms.randomString();
         final ContainerRequestContext mockContainerRequestContext = mock(ContainerRequestContext.class);
         final MultivaluedMap<String, String> headersMap = new MultivaluedHashMap<>();
-        headersMap.add(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_VALUE_PREFIX + principal);
+        headersMap.add(HttpHeaders.AUTHORIZATION, PRINCIPAL_HEADER_VALUE_PREFIX + " " + principal);
+        when(mockContainerRequestContext.getHeaders()).thenReturn(headersMap);
+        final ContainerSecurityRequestFilter containerSecurityRequestFilter = new ContainerSecurityRequestFilter();
+
+        // When
+        containerSecurityRequestFilter.filter(mockContainerRequestContext);
+
+        // Then
+        final ArgumentCaptor<BasicSecurityContext> securityContextCaptor = ArgumentCaptor
+                .forClass(BasicSecurityContext.class);
+        verifyStatic();
+        SecurityContextHolder.set(securityContextCaptor.capture());
+        assertThat(securityContextCaptor.getValue().principal(), is(principal));
+    }
+
+    @Test
+    public void shouldSetPrincipal_withPrincipalHeaderAndAgentHeader() throws Exception {
+        // Given
+        mockStatic(SecurityContextHolder.class);
+        final String principal = Randoms.randomString();
+        final String agent = Randoms.randomString();
+        final ContainerRequestContext mockContainerRequestContext = mock(ContainerRequestContext.class);
+        final MultivaluedMap<String, String> headersMap = new MultivaluedHashMap<>();
+        headersMap.add(HttpHeaders.AUTHORIZATION, PRINCIPAL_HEADER_VALUE_PREFIX + " " + principal);
+        headersMap.add(HttpHeaders.AUTHORIZATION, AGENT_HEADER_VALUE_PREFIX + " " + agent);
+        when(mockContainerRequestContext.getHeaders()).thenReturn(headersMap);
+        final ContainerSecurityRequestFilter containerSecurityRequestFilter = new ContainerSecurityRequestFilter();
+
+        // When
+        containerSecurityRequestFilter.filter(mockContainerRequestContext);
+
+        // Then
+        final ArgumentCaptor<AgentSecurityContext> securityContextCaptor = ArgumentCaptor
+                .forClass(AgentSecurityContext.class);
+        verifyStatic();
+        SecurityContextHolder.set(securityContextCaptor.capture());
+        assertThat(securityContextCaptor.getValue().principal(), is(principal));
+        assertThat(securityContextCaptor.getValue().agent(), is(agent));
+    }
+
+    @Test
+    public void shouldNotSetPrincipal_withGeneralAuthorizationHeader() throws Exception {
+        // Given
+        mockStatic(SecurityContextHolder.class);
+        final String authorizationHeader = Randoms.randomString();
+        final ContainerRequestContext mockContainerRequestContext = mock(ContainerRequestContext.class);
+        final MultivaluedMap<String, String> headersMap = new MultivaluedHashMap<>();
+        headersMap.add(HttpHeaders.AUTHORIZATION, authorizationHeader);
         when(mockContainerRequestContext.getHeaders()).thenReturn(headersMap);
         final ContainerSecurityRequestFilter containerSecurityRequestFilter = new ContainerSecurityRequestFilter();
 
@@ -57,25 +109,6 @@ public class ContainerSecurityRequestFilterTest {
 
         // Then
         verifyStatic();
-        SecurityContextHolder.setPrincipal(principal);
-    }
-
-    @Test
-    public void shouldNotSetPrincipal_withGeneralAuthorizationHeader() throws Exception {
-        // Given
-        mockStatic(SecurityContextHolder.class);
-        final String principal = Randoms.randomString();
-        final ContainerRequestContext mockContainerRequestContext = mock(ContainerRequestContext.class);
-        final MultivaluedMap<String, String> headersMap = new MultivaluedHashMap<>();
-        headersMap.add(HttpHeaders.AUTHORIZATION, principal);
-        when(mockContainerRequestContext.getHeaders()).thenReturn(headersMap);
-        final ContainerSecurityRequestFilter containerSecurityRequestFilter = new ContainerSecurityRequestFilter();
-
-        // When
-        containerSecurityRequestFilter.filter(mockContainerRequestContext);
-
-        // Then
-        verifyStatic(never());
-        SecurityContextHolder.setPrincipal(principal);
+        SecurityContextHolder.clear();
     }
 }

--- a/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityResponseFilterTest.java
+++ b/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/http/filter/security/ContainerSecurityResponseFilterTest.java
@@ -47,6 +47,6 @@ public class ContainerSecurityResponseFilterTest {
 
         // Then
         verifyStatic();
-        SecurityContextHolder.clearPrincipal();
+        SecurityContextHolder.clear();
     }
 }


### PR DESCRIPTION
@ClickTravel/cheddarchapter

This is a *non-breaking* change as I have added deprecated methods to allow the previous ```getPrincipal()```, ```setPrincipal()``` and ```clearPrincipal()``` methods to work.

There is still some uncertainly (need discussion from API Chapter) over the choice of HTTP Headers to contain the principal/agent ids in the ```ContainerSecurityRequestFilter``` class, but the rest can still be reviewed.