### PR TITLE
FC-92 Do not bring down app if REST request counting misbehaves

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/status/RestAdapterStatusRequestFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/status/RestAdapterStatusRequestFilter.java
@@ -18,6 +18,7 @@ package com.clicktravel.cheddar.server.http.filter.status;
 
 import java.io.IOException;
 
+import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -28,6 +29,7 @@ import com.clicktravel.cheddar.server.application.status.RestAdapterStatusHolder
 
 @Provider
 @PreMatching
+@Priority(500)
 public class RestAdapterStatusRequestFilter implements ContainerRequestFilter {
 
     private final RestAdapterStatusHolder restAdapterStatusHolder;


### PR DESCRIPTION
It is not clear why sometimes REST request counting goes wrong, making the count go below 0. If it should, log a (single) WARN rather than throw an exception which cannot be mapped correctly.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>