### PR TITLE
API-46 Fix Content-Type header in responses, including charset

### DIFF
--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/charset/CharsetResponseFilter.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/http/filter/charset/CharsetResponseFilter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.server.http.filter.charset;
+
+import java.io.IOException;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Response filter that sets default value for {@code charset} parameter for {@code Content-Type} header if not already
+ * set
+ */
+@Provider
+@Priority(Priorities.HEADER_DECORATOR)
+public class CharsetResponseFilter implements ContainerResponseFilter {
+
+    private static final String DEFAULT_CHARSET = "utf-8";
+
+    @Override
+    public void filter(final ContainerRequestContext requestContext, final ContainerResponseContext responseContext)
+            throws IOException {
+        final MediaType type = responseContext.getMediaType();
+        if (type != null && !type.getParameters().containsKey(MediaType.CHARSET_PARAMETER)) {
+            responseContext.getHeaders().putSingle(HttpHeaders.CONTENT_TYPE, type.withCharset(DEFAULT_CHARSET));
+        }
+    }
+}

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/resource/status/StatusResource.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/resource/status/StatusResource.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -63,6 +65,7 @@ public class StatusResource {
 
     @GET
     @Path("/")
+    @Produces(MediaType.APPLICATION_JSON)
     public Response getStatus() {
         // Test if REST requests other than this one are in progress
         final boolean processingRestRequest = restAdapterStatusHolder.restRequestsInProgress() > 1;
@@ -107,6 +110,7 @@ public class StatusResource {
 
     @GET
     @Path("/healthCheck")
+    @Produces(MediaType.TEXT_PLAIN)
     public Response getHealthCheck() {
         if (restAdapterStatusHolder.isAcceptingRequests()) {
             return Response.status(Status.OK).entity("Ready").build();

--- a/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/http/filter/charset/CharsetResponseFilterTest.java
+++ b/cheddar/cheddar-server/src/test/java/com/clicktravel/cheddar/server/http/filter/charset/CharsetResponseFilterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.server.http.filter.charset;
+
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.junit.Test;
+
+@SuppressWarnings("unchecked")
+public class CharsetResponseFilterTest {
+
+    @Test
+    public void shouldAddCharsetParameter_onFilter() throws Exception {
+        // Given
+        final ContainerRequestContext mockContainerRequestContext = mock(ContainerRequestContext.class);
+        final ContainerResponseContext mockContainerResponseContext = mock(ContainerResponseContext.class);
+        final MediaType mockMediaType = mock(MediaType.class);
+        when(mockContainerResponseContext.getMediaType()).thenReturn(mockMediaType);
+        final MediaType mockTypeWithCharset = mock(MediaType.class);
+        when(mockMediaType.withCharset("utf-8")).thenReturn(mockTypeWithCharset);
+        final HashMap<String, String> parameters = new HashMap<String, String>();
+        when(mockMediaType.getParameters()).thenReturn(parameters);
+        final MultivaluedMap<String, Object> mockHeadersMap = mock(MultivaluedMap.class);
+        when(mockContainerResponseContext.getHeaders()).thenReturn(mockHeadersMap);
+        final CharsetResponseFilter charsetResponseFilter = new CharsetResponseFilter();
+
+        // When
+        charsetResponseFilter.filter(mockContainerRequestContext, mockContainerResponseContext);
+
+        // Then
+        verify(mockHeadersMap).putSingle(HttpHeaders.CONTENT_TYPE, mockTypeWithCharset);
+    }
+
+    @Test
+    public void shouldNotOverrideCharsetParameter_onFilter() throws Exception {
+        // Given
+        final ContainerRequestContext mockContainerRequestContext = mock(ContainerRequestContext.class);
+        final ContainerResponseContext mockContainerResponseContext = mock(ContainerResponseContext.class);
+        final MediaType mockMediaType = mock(MediaType.class);
+        when(mockContainerResponseContext.getMediaType()).thenReturn(mockMediaType);
+        final HashMap<String, String> parameters = new HashMap<String, String>();
+        parameters.put(MediaType.CHARSET_PARAMETER, randomString(10));
+        when(mockMediaType.getParameters()).thenReturn(parameters);
+        final MultivaluedMap<String, Object> mockHeadersMap = mock(MultivaluedMap.class);
+        when(mockContainerResponseContext.getHeaders()).thenReturn(mockHeadersMap);
+        final CharsetResponseFilter charsetResponseFilter = new CharsetResponseFilter();
+
+        // When
+        charsetResponseFilter.filter(mockContainerRequestContext, mockContainerResponseContext);
+
+        // Then
+        verifyZeroInteractions(mockHeadersMap);
+    }
+
+    @Test
+    public void shouldNotSetContentTypeOnResponseWithoutMediaType_onFilter() throws Exception {
+        // Given
+        final ContainerRequestContext mockContainerRequestContext = mock(ContainerRequestContext.class);
+        final ContainerResponseContext mockContainerResponseContext = mock(ContainerResponseContext.class);
+        when(mockContainerResponseContext.getMediaType()).thenReturn(null);
+        final MultivaluedMap<String, Object> mockHeadersMap = mock(MultivaluedMap.class);
+        when(mockContainerResponseContext.getHeaders()).thenReturn(mockHeadersMap);
+        final CharsetResponseFilter charsetResponseFilter = new CharsetResponseFilter();
+
+        // When
+        charsetResponseFilter.filter(mockContainerRequestContext, mockContainerResponseContext);
+
+        // Then
+        verifyZeroInteractions(mockHeadersMap);
+    }
+}


### PR DESCRIPTION
```/status``` now returns ```application/json```
```/status/healthCheck``` now returns ```text/plain```
All endpoints have default ```charset=utf-8``` if ```Content-Type``` header is present in response

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>