### PR TITLE
Support for hash key query

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplate.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplate.java
@@ -229,10 +229,17 @@ public class DynamoDocumentStoreTemplate extends AbstractDynamoDbTemplate {
 
         if (itemConfiguration.hasIndexOn(query.getAttributeName())
                 && query.getCondition().getComparisonOperator().equals(Operators.EQUALS)) {
-            final Index index = table.getIndex(query.getAttributeName() + "_idx");
 
             final QuerySpec querySpec = generateQuerySpec(query);
-            final ItemCollection<QueryOutcome> queryOutcome = index.query(querySpec);
+            final ItemCollection<QueryOutcome> queryOutcome;
+
+            if (itemConfiguration.primaryKeyDefinition().propertyName().equals(query.getAttributeName())) {
+                // if the query is for the has then call query on table
+                queryOutcome = table.query(querySpec);
+            } else {
+                final Index index = table.getIndex(query.getAttributeName() + "_idx");
+                queryOutcome = index.query(querySpec);
+            }
 
             final Iterator<com.amazonaws.services.dynamodbv2.document.Item> iterator = queryOutcome.iterator();
             while (iterator.hasNext()) {

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplate.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDocumentStoreTemplate.java
@@ -242,7 +242,7 @@ public class DynamoDocumentStoreTemplate extends AbstractDynamoDbTemplate {
             }
 
             final Iterator<com.amazonaws.services.dynamodbv2.document.Item> iterator = queryOutcome.iterator();
-            while (iterator.hasNext()) {
+            while (iterator != null && iterator.hasNext()) {
                 final com.amazonaws.services.dynamodbv2.document.Item item = iterator.next();
                 totalItems.add(stringToItem(item.toJSON(), itemClass));
             }


### PR DESCRIPTION
Currently if you try to perform an attribute query on the has value, for example if you want to query hash without range it fails as it attempts to query an index table instead of the table itself.

This change checks that if the query name is the same as the PK because you can't have multiple keys with the same name then it will instead query the table directly. I have noticed an issue with index query around support for multiple keys but i will raise a separate bug report for that.

Signed-off-by: Robin Smith <robin.smith@clicktravel.com>