### PR TITLE
Remove empty path annotation on GET /status

### DIFF
--- a/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/database/InMemoryDatabaseTemplate.java
+++ b/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/database/InMemoryDatabaseTemplate.java
@@ -140,7 +140,7 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
                 final String uniqueConstraintPropertyValue = uniqueConstraintPropertyValue(propertyValue);
                 final ItemId existingItemId = uniqueValues.get(uniqueConstraintPropertyValue);
                 if (existingItemId != null) {
-                    throw new ItemConstraintViolationException(propertyName, "Already is use");
+                    throw new ItemConstraintViolationException(propertyName, "Already in use");
                 }
                 newConstraints.put(uniqueConstraintKey, uniqueConstraintPropertyValue);
             }

--- a/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/resource/status/StatusResource.java
+++ b/cheddar/cheddar-server/src/main/java/com/clicktravel/cheddar/server/rest/resource/status/StatusResource.java
@@ -64,7 +64,6 @@ public class StatusResource {
     }
 
     @GET
-    @Path("/")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getStatus() {
         // Test if REST requests other than this one are in progress


### PR DESCRIPTION
Removing this unnecessary annotation gets rid of a WARN log message on application start

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>