### PR TITLE
Use MultivaluedMap (interface) instead of concrete class for method signatures

### DIFF
--- a/commons/commons-httpclient/src/main/java/com/clicktravel/common/http/client/HttpClient.java
+++ b/commons/commons-httpclient/src/main/java/com/clicktravel/common/http/client/HttpClient.java
@@ -32,6 +32,7 @@ import javax.ws.rs.RedirectionException;
 import javax.ws.rs.client.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 import org.glassfish.jersey.client.ClientConfig;
@@ -57,19 +58,19 @@ public class HttpClient {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final WebTarget target;
     private final MediaType accept;
-    private final MultivaluedHashMap<String, String> headers;
-    private final MultivaluedHashMap<String, Object> clientHeaders;
+    private final MultivaluedMap<String, String> headers;
+    private final MultivaluedMap<String, Object> clientHeaders;
     private final boolean ignoreSslErrors;
 
     /**
      * Private constructor to initiate a HttpClient with a base URL.
-     *
+     * 
      * @param baseUri The base URL to which all HTTP requests are to be made
      * @param ignoreSslErrors Flag can be set to true when any SSL-related errors should be ignored.
      * @param accept The media type which is acceptable for all request by this given HTTP client
      */
     private HttpClient(final String baseUri, final boolean ignoreSslErrors, final MediaType accept,
-            final MultivaluedHashMap<String, String> headers) {
+            final MultivaluedMap<String, String> headers) {
         final ClientBuilder clientBuilder = ClientBuilder.newBuilder();
         this.ignoreSslErrors = ignoreSslErrors;
         if (this.ignoreSslErrors) {
@@ -83,9 +84,8 @@ public class HttpClient {
         this.accept = accept;
     }
 
-    private MultivaluedHashMap<String, Object> mapHeadersToClientHeaders(
-            final MultivaluedHashMap<String, String> headers) {
-        final MultivaluedHashMap<String, Object> clientHeaders = new MultivaluedHashMap<>();
+    private MultivaluedMap<String, Object> mapHeadersToClientHeaders(final MultivaluedMap<String, String> headers) {
+        final MultivaluedMap<String, Object> clientHeaders = new MultivaluedHashMap<>();
         for (final Entry<String, List<String>> entry : headers.entrySet()) {
             final List<Object> values = new ArrayList<>();
             values.addAll(entry.getValue());
@@ -96,7 +96,7 @@ public class HttpClient {
 
     /**
      * Private constructor to initiate HttpClient with base URL and HTTP basic authentication
-     *
+     * 
      * @param baseUri The base URL to which all HTTP requests are to be made
      * @param username The username part of HTTP basic authentication
      * @param password The password part of HTTP basic authentication
@@ -104,14 +104,14 @@ public class HttpClient {
      * @param accept The media type which is acceptable for all request by this given HTTP client
      */
     private HttpClient(final String baseUri, final String username, final String password,
-            final boolean ignoreSslErrors, final MediaType accept, final MultivaluedHashMap<String, String> headers) {
+            final boolean ignoreSslErrors, final MediaType accept, final MultivaluedMap<String, String> headers) {
         this(baseUri, ignoreSslErrors, accept, headers);
         target.register(HttpAuthenticationFeature.basicBuilder().credentials(username, password).build());
     }
 
     /**
      * Private constructor to initiate HttpClient with base URL and OAuth 2.0 authentication.
-     *
+     * 
      * @param baseUri The base URL to which all HTTP requests are to be made
      * @param accept The media type which is acceptable for all request by this given HTTP client
      * @param headers The header values found within the HTTP request
@@ -119,7 +119,7 @@ public class HttpClient {
      */
 
     private HttpClient(final String baseUri, final boolean ignoreSslErrors, final MediaType accept,
-            final MultivaluedHashMap<String, String> headers, final OAuthConfiguration oauthConfiguration) {
+            final MultivaluedMap<String, String> headers, final OAuthConfiguration oauthConfiguration) {
         target = getOAuthAuthenticatedTarget(baseUri, oauthConfiguration);
         clientHeaders = mapHeadersToClientHeaders(headers);
         this.headers = headers;
@@ -189,18 +189,18 @@ public class HttpClient {
         return clientBuilder;
     }
 
-    public MultivaluedHashMap<String, String> headers() {
+    public MultivaluedMap<String, String> headers() {
         return headers;
     }
 
     /**
      * Returns the redirect from a GET request, or <code>null</code> if no redirect is available.
-     *
+     * 
      * @param path The path which wil be requested via GET
      * @param params The URL params which will be passed in the request
      * @return The URI for the redirect or <code>null</code> if there is no redirect
      */
-    public URI getRedirectLocation(final String path, final MultivaluedHashMap<String, String> params) {
+    public URI getRedirectLocation(final String path, final MultivaluedMap<String, String> params) {
         try {
             requestBuilder(path, params).get(ClientResponse.class);
             return null;
@@ -214,9 +214,9 @@ public class HttpClient {
 
     /**
      * Convenience method to return redirect URL without specifying any query parameters.
-     *
+     * 
      * @see#getRedirectLocation(String, Map)
-     *
+     * 
      * @param path The path which will be requested via GET
      * @return The URI returned for the redirect. Returns null if there is no redirect
      */
@@ -224,7 +224,7 @@ public class HttpClient {
         return getRedirectLocation(path, new MultivaluedHashMap<String, String>());
     }
 
-    private Invocation.Builder requestBuilder(final String path, final MultivaluedHashMap<String, String> params) {
+    private Invocation.Builder requestBuilder(final String path, final MultivaluedMap<String, String> params) {
         if (path == null || params == null) {
             throw new IllegalStateException("Path or params cannot be null");
         }
@@ -238,20 +238,20 @@ public class HttpClient {
     /**
      * Convenience method to get hold of the client directly allowing you to call more complex methods on the client
      * such as a post entity with variant language headers
-     *
+     * 
      * @param path The path to which the request needs to be made, required
      * @param params The query parameters appended to the path, required but can be empty
      * @return
      */
-    public Invocation.Builder getHttpClientBuilder(final String path, final MultivaluedHashMap<String, String> params) {
+    public Invocation.Builder getHttpClientBuilder(final String path, final MultivaluedMap<String, String> params) {
         return requestBuilder(path, params);
     }
 
     /**
      * Convenience method to make HTTP GET request to a given URL without specifying any query parameters.
-     *
+     * 
      * @see #get(String, Map)
-     *
+     * 
      * @param path The path to which the GET request needs to be made
      * @return The HTTP response which is returned as a result of the GET request
      */
@@ -262,20 +262,20 @@ public class HttpClient {
 
     /**
      * Makes a HTTP GET request to a given URL
-     *
+     * 
      * @param path The path to which the GET request needs to be made
      * @return The HTTP response which is returned as a result of the GET request
      */
-    public Response get(final String path, final MultivaluedHashMap<String, String> params) {
+    public Response get(final String path, final MultivaluedMap<String, String> params) {
         final Response response = requestBuilder(path, params).accept(accept).get();
         return response;
     }
 
     /**
      * Convenience method to make HTTP DELETE request to a given URL without specifying any query parameters.
-     *
+     * 
      * @see #get(String, Map)
-     *
+     * 
      * @param path The path to which the DELETE request needs to be made
      * @return The HTTP response which is returned as a result of the DELETE request
      */
@@ -286,20 +286,20 @@ public class HttpClient {
 
     /**
      * Makes a HTTP DELETE request to a given URL
-     *
+     * 
      * @param path The path to which the DELETE request needs to be made
      * @return The HTTP response which is returned as a result of the DELETE request
      */
-    public Response delete(final String path, final MultivaluedHashMap<String, String> params) {
+    public Response delete(final String path, final MultivaluedMap<String, String> params) {
         final Response response = requestBuilder(path, params).accept(accept).delete();
         return response;
     }
 
     /**
      * Makes HTTP POST request with a specified entity
-     *
+     * 
      * @see #put(String, Object, MediaType)
-     *
+     * 
      * @param path The path to which the request should be made
      * @param entity The entity which is to be POSTed
      * @param contentType The content type of the entity to be POSTed
@@ -313,14 +313,14 @@ public class HttpClient {
 
     /**
      * Makes HTTP POST request with a specified entity
-     *
+     * 
      * @param path The path to which the request should be made
      * @param params The query parameters appended to the path
      * @param entity The entity which is to be POSTed
      * @param contentType The content type of the entity to be POSTed
      * @return The HTTP response which is returned as a result of the POST request
      */
-    public Response post(final String path, final MultivaluedHashMap<String, String> params, final Object entity,
+    public Response post(final String path, final MultivaluedMap<String, String> params, final Object entity,
             final MediaType contentType) {
         final Response response = requestBuilder(path, params).post(Entity.entity(entity, contentType));
         return response;
@@ -328,9 +328,9 @@ public class HttpClient {
 
     /**
      * Makes HTTP PUT request with a specified entity
-     *
+     * 
      * @see post(String, Object, MediaType)
-     *
+     * 
      * @param path The path to which the request should be made
      * @param entity The entity which is to be PUT
      * @param contentType The content type of the entity to be PUT
@@ -360,7 +360,7 @@ public class HttpClient {
         private String password;
         private boolean ignoreSslErrors = false;
         private final MediaType acceptType = MediaType.WILDCARD_TYPE;
-        private MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+        private MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
         private OAuthConfiguration oauthConfiguration;
 
         public static Builder httpClient() {
@@ -387,7 +387,7 @@ public class HttpClient {
             return this;
         }
 
-        public Builder withHeaders(final MultivaluedHashMap<String, String> headers) {
+        public Builder withHeaders(final MultivaluedMap<String, String> headers) {
             this.headers = headers;
             return this;
         }


### PR DESCRIPTION
Some methods in HttpClient incorrectly use `MultivaluedHashMap` (a concrete class) rather than the general `MultivaluedMap` interface in their signatures.