### PR TITLE
Add MediaType for CDM

### DIFF
--- a/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/media/MediaTypes.java
+++ b/cheddar/cheddar-rest/src/main/java/com/clicktravel/cheddar/rest/media/MediaTypes.java
@@ -16,8 +16,12 @@
  */
 package com.clicktravel.cheddar.rest.media;
 
+import javax.ws.rs.core.MediaType;
+
 public class MediaTypes {
 
     public static final String CDM_V1_JSON = "application/vnd.clicktravel.schema-v1+json";
+
+    public static final MediaType CDM_V1_JSON_TYPE = new MediaType("application", "vnd.clicktravel.schema-v1+json");
 
 }


### PR DESCRIPTION
This adds an alternative for obtaining the existing media type for CDM. For some JAX-RS methods this offers stronger typing and a minor performance benefit. The String version is retained for use with annotations. The naming convention (_TYPE) is taken from the MediaType class.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>