### PR TITLE
DET-9 Update AWS SDK and Joda-Time dependencies

### DIFF
--- a/cheddar/cheddar-integration-aws/build.gradle
+++ b/cheddar/cheddar-integration-aws/build.gradle
@@ -8,21 +8,21 @@ dependencies {
     compile project(':cheddar:cheddar-messaging')
     compile project(':cheddar:cheddar-persistence')
 
-    compile 'com.amazonaws:aws-java-sdk-s3:1.9.23'
-    compile 'com.amazonaws:aws-java-sdk-dynamodb:1.9.23'
-    compile 'com.amazonaws:aws-java-sdk-ses:1.9.23'
-    compile 'com.amazonaws:aws-java-sdk-sns:1.9.23'
-    compile 'com.amazonaws:aws-java-sdk-sqs:1.9.23'
-    compile 'com.amazonaws:aws-java-sdk-cloudsearch:1.9.23'
-    compile 'com.amazonaws:aws-java-sdk-cloudwatch:1.9.23'
-    compile 'com.amazonaws:aws-java-sdk-lambda:1.9.23'
+    compile 'com.amazonaws:aws-java-sdk-s3:1.10.20'
+    compile 'com.amazonaws:aws-java-sdk-dynamodb:1.10.20'
+    compile 'com.amazonaws:aws-java-sdk-ses:1.10.20'
+    compile 'com.amazonaws:aws-java-sdk-sns:1.10.20'
+    compile 'com.amazonaws:aws-java-sdk-sqs:1.10.20'
+    compile 'com.amazonaws:aws-java-sdk-cloudsearch:1.10.20'
+    compile 'com.amazonaws:aws-java-sdk-cloudwatch:1.10.20'
+    compile 'com.amazonaws:aws-java-sdk-lambda:1.10.20'
     compile "org.springframework:spring-context-support:${springVersion}"
     compile "org.springframework:spring-aop:${springVersion}"
 
     compile "org.aspectj:aspectjrt:1.7.4"
     compile "org.aspectj:aspectjweaver:1.7.4"
     compile 'javax.mail:mail:1.4.7'
-    compile 'joda-time:joda-time:2.4'
+    compile 'joda-time:joda-time:2.8.2'
     compile 'org.slf4j:slf4j-api:1.7.5'
     compile 'org.slf4j:jcl-over-slf4j:1.7.5'    //Required for AWS SDK
     compile 'net.spy:spymemcached:2.11.4' //USED to connect to memcache nodes - the aws version of this file is not in a public repo

--- a/cheddar/cheddar-metrics/build.gradle
+++ b/cheddar/cheddar-metrics/build.gradle
@@ -2,6 +2,6 @@ apply from: '../../test.gradle'
 
 dependencies {
 	compile 'io.intercom:intercom-java:1.1.1'
-	compile 'joda-time:joda-time:2.7'
+	compile 'joda-time:joda-time:2.8.2'
 
 }

--- a/commons/commons-lang/build.gradle
+++ b/commons/commons-lang/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile 'joda-time:joda-time:2.4'
+    compile 'joda-time:joda-time:2.8.2'
     compile 'javax.mail:mail:1.4.7'
     
     testCompile 'junit:junit:4.11'


### PR DESCRIPTION
Using Java 8 with older dependencies has issues concerning signed AWS requests.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>