### PR TITLE
Allow setting of a maximum page size to be used with DynamoDB reads to attempt to allow better control of throughputs

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDbTemplate.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDbTemplate.java
@@ -37,6 +37,7 @@ import com.clicktravel.cheddar.infrastructure.persistence.database.exception.Non
 import com.clicktravel.cheddar.infrastructure.persistence.database.exception.OptimisticLockException;
 import com.clicktravel.cheddar.infrastructure.persistence.database.exception.handler.PersistenceExceptionHandler;
 import com.clicktravel.cheddar.infrastructure.persistence.database.query.*;
+import com.clicktravel.cheddar.infrastructure.persistence.document.search.exception.UnsuccessfulSearchException;
 import com.clicktravel.cheddar.infrastructure.persistence.exception.PersistenceResourceFailureException;
 
 public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchDatabaseTemplate {
@@ -54,8 +55,8 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
             final T item = marshallIntoObject(itemClass, attributeMap);
             return item;
         } catch (final ItemClassDiscriminatorMismatchException e) {
-            throw new NonExistentItemException(String.format("The item of type [%s] with id [%s] does not exist",
-                    itemClass.getName(), itemId));
+            throw new NonExistentItemException(
+                    String.format("The item of type [%s] with id [%s] does not exist", itemClass.getName(), itemId));
         }
 
     }
@@ -82,8 +83,8 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
         }
 
         if (getItemResult == null || getItemResult.getItem() == null) {
-            throw new NonExistentItemException(String.format("The item of type [%s] with id [%s] does not exist",
-                    itemClass.getName(), itemId));
+            throw new NonExistentItemException(
+                    String.format("The item of type [%s] with id [%s] does not exist", itemClass.getName(), itemId));
         } else {
             return getItemResult.getItem();
         }
@@ -107,8 +108,8 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
         final AttributeValue supportingKeyValue = new AttributeValue();
         if (CompoundPrimaryKeyDefinition.class.isAssignableFrom(primaryKeyDefinition.getClass())) {
             final CompoundPrimaryKeyDefinition compoundPrimaryKeyDefinition = (CompoundPrimaryKeyDefinition) primaryKeyDefinition;
-            final ScalarAttributeType supportingKeyAttributeType = getAttributeType(compoundPrimaryKeyDefinition
-                    .propertyType());
+            final ScalarAttributeType supportingKeyAttributeType = getAttributeType(
+                    compoundPrimaryKeyDefinition.propertyType());
             switch (supportingKeyAttributeType) {
                 case N:
                     supportingKeyValue.withN(itemId.supportingValue());
@@ -135,11 +136,10 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
             }
         } else if (VariantItemConfiguration.class.isAssignableFrom(itemConfiguration.getClass())) {
             final VariantItemConfiguration variantItemConfiguration = (VariantItemConfiguration) itemConfiguration;
-            final AttributeValue discriminatorAttribute = itemAttributeMap.get(variantItemConfiguration
-                    .parentItemConfiguration().discriminator());
-            if (discriminatorAttribute == null
-                    || !((VariantItemConfiguration) itemConfiguration).discriminatorValue().equals(
-                            discriminatorAttribute.getS())) {
+            final AttributeValue discriminatorAttribute = itemAttributeMap
+                    .get(variantItemConfiguration.parentItemConfiguration().discriminator());
+            if (discriminatorAttribute == null || !((VariantItemConfiguration) itemConfiguration).discriminatorValue()
+                    .equals(discriminatorAttribute.getS())) {
                 throw new ItemClassDiscriminatorMismatchException();
             }
         }
@@ -170,7 +170,8 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
     }
 
     @Override
-    public <T extends Item> T create(final T item, final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
+    public <T extends Item> T create(final T item,
+            final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
         final ItemConfiguration itemConfiguration = getItemConfiguration(item.getClass());
         final Collection<PropertyDescriptor> createdConstraintPropertyDescriptors = createUniqueConstraintIndexes(item,
                 itemConfiguration);
@@ -220,8 +221,8 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
         }
         if (VariantItemConfiguration.class.isAssignableFrom(itemConfiguration.getClass())) {
             final VariantItemConfiguration variantItemConfiguration = (VariantItemConfiguration) itemConfiguration;
-            attributeMap.put(variantItemConfiguration.parentItemConfiguration().discriminator(), new AttributeValue(
-                    variantItemConfiguration.discriminatorValue()));
+            attributeMap.put(variantItemConfiguration.parentItemConfiguration().discriminator(),
+                    new AttributeValue(variantItemConfiguration.discriminatorValue()));
         }
         return attributeMap;
     }
@@ -260,7 +261,8 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
     }
 
     @Override
-    public <T extends Item> T update(final T item, final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
+    public <T extends Item> T update(final T item,
+            final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
         final ItemConfiguration itemConfiguration = getItemConfiguration(item.getClass());
         if (item.getVersion() == null) {
             return create(item);
@@ -333,13 +335,13 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
         try {
             return marshallIntoObject(itemClass, attributeMap);
         } catch (final ItemClassDiscriminatorMismatchException e) {
-            throw new NonExistentItemException(String.format("The item of type [%s] with id [%s] does not exist",
-                    itemClass.getName(), itemId));
+            throw new NonExistentItemException(
+                    String.format("The item of type [%s] with id [%s] does not exist", itemClass.getName(), itemId));
         }
     }
 
-    public <T extends Item> Collection<UniqueConstraint> getUpdatedUniqueConstraints(final T item,
-            final T previousItem, final ItemConfiguration itemConfiguration) {
+    public <T extends Item> Collection<UniqueConstraint> getUpdatedUniqueConstraints(final T item, final T previousItem,
+            final ItemConfiguration itemConfiguration) {
         final Map<String, AttributeValue> previousItemAttributeMap = getAttributeMap(previousItem, itemConfiguration,
                 item.getVersion());
         if (!previousItemAttributeMap.get(VERSION_ATTRIBUTE).getN().equals(String.valueOf(item.getVersion()))) {
@@ -393,7 +395,8 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
         key.put(primaryKeyDefinition.propertyName(), new AttributeValue(itemId.value()));
         if (CompoundPrimaryKeyDefinition.class.isAssignableFrom(primaryKeyDefinition.getClass())) {
             final CompoundPrimaryKeyDefinition compoundPrimaryKeyDefinition = (CompoundPrimaryKeyDefinition) primaryKeyDefinition;
-            key.put(compoundPrimaryKeyDefinition.supportingPropertyName(), new AttributeValue(itemId.supportingValue()));
+            key.put(compoundPrimaryKeyDefinition.supportingPropertyName(),
+                    new AttributeValue(itemId.supportingValue()));
         }
         final Map<String, ExpectedAttributeValue> expectedResults = new HashMap<>();
         expectedResults.put(VERSION_ATTRIBUTE,
@@ -412,21 +415,38 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
 
     @Override
     public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass) {
+        return fetch(query, itemClass, null);
+    }
+
+    @Override
+    public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass,
+            final Integer maxPageSize) {
         final long startTimeMillis = System.currentTimeMillis();
+
+        if (maxPageSize != null && maxPageSize < 1) {
+            throw new UnsuccessfulSearchException(
+                    "MaxPageSize value " + maxPageSize + " not valid, must be greater than 0");
+        }
+
         Collection<T> result;
+
         if (query instanceof AttributeQuery) {
-            result = executeQuery((AttributeQuery) query, itemClass);
+            result = executeQuery((AttributeQuery) query, itemClass, maxPageSize);
         } else if (query instanceof KeySetQuery) {
             result = executeQuery((KeySetQuery) query, itemClass);
         } else {
             throw new UnsupportedQueryException(query.getClass());
         }
+
         final long elapsedTimeMillis = System.currentTimeMillis() - startTimeMillis;
+
         logger.debug("Database fetch executed in " + elapsedTimeMillis + "ms. Query:[" + query + "]");
+
         return result;
     }
 
-    private <T extends Item> Collection<T> executeQuery(final AttributeQuery query, final Class<T> itemClass) {
+    private <T extends Item> Collection<T> executeQuery(final AttributeQuery query, final Class<T> itemClass,
+            final Integer maxPageSize) {
         final ItemConfiguration itemConfiguration = getItemConfiguration(itemClass);
         final com.amazonaws.services.dynamodbv2.model.Condition condition = new com.amazonaws.services.dynamodbv2.model.Condition();
 
@@ -463,39 +483,56 @@ public class DynamoDbTemplate extends AbstractDynamoDbTemplate implements BatchD
         final List<T> totalItems = new ArrayList<>();
         Map<String, AttributeValue> lastEvaluatedKey = null;
         final String tableName = databaseSchemaHolder.schemaName() + "." + itemConfiguration.tableName();
+
         if (itemConfiguration.hasIndexOn(query.getAttributeName())) {
             do {
                 final String queryAttributeName = query.getAttributeName();
                 final PrimaryKeyDefinition primaryKeyDefinition = itemConfiguration.primaryKeyDefinition();
                 final String primaryKeyPropertyName = primaryKeyDefinition.propertyName();
                 final boolean isPrimaryKeyQuery = queryAttributeName.equals(primaryKeyPropertyName);
+
                 final QueryRequest queryRequest = new QueryRequest().withTableName(tableName)
                         .withKeyConditions(conditions).withExclusiveStartKey(lastEvaluatedKey);
+
+                if (maxPageSize != null) {
+                    queryRequest.withLimit(maxPageSize);
+                }
+
                 if (!isPrimaryKeyQuery) {
                     queryRequest.withIndexName(queryAttributeName + "_idx");
                 }
 
                 final QueryResult queryResult;
+
                 try {
                     queryResult = amazonDynamoDbClient.query(queryRequest);
                 } catch (final AmazonServiceException e) {
                     throw new PersistenceResourceFailureException("Failure while attempting DynamoDb Query", e);
                 }
+
                 totalItems.addAll(marshallIntoObjects(itemClass, queryResult.getItems()));
                 lastEvaluatedKey = queryResult.getLastEvaluatedKey();
             } while (lastEvaluatedKey != null);
 
         } else {
             logger.debug("Performing table scan with query: " + query);
+
             do {
                 final ScanRequest scanRequest = new ScanRequest().withTableName(tableName).withScanFilter(conditions)
                         .withExclusiveStartKey(lastEvaluatedKey);
+
+                if (maxPageSize != null) {
+                    scanRequest.withLimit(maxPageSize);
+                }
+
                 final ScanResult scanResult;
+
                 try {
                     scanResult = amazonDynamoDbClient.scan(scanRequest);
                 } catch (final AmazonServiceException e) {
                     throw new PersistenceResourceFailureException("Failure while attempting DynamoDb Scan", e);
                 }
+
                 totalItems.addAll(marshallIntoObjects(itemClass, scanResult.getItems()));
                 lastEvaluatedKey = scanResult.getLastEvaluatedKey();
             } while (lastEvaluatedKey != null);

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDbTemplateTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDbTemplateTest.java
@@ -226,7 +226,7 @@ public class DynamoDbTemplateTest {
     @Test
     public void shouldFetch_withAttributeQueryOnIndexWithMaxPageSizeSet() throws Exception {
         // Given
-        final Integer maxPageSize = Randoms.randomIntInRange(1, 100);
+        final int maxPageSize = Randoms.randomIntInRange(0, 100);
         final AttributeQuery query = mock(AttributeQuery.class);
         final Condition mockCondition = mock(Condition.class);
         when(mockCondition.getComparisonOperator()).thenReturn(Operators.EQUALS);
@@ -265,7 +265,7 @@ public class DynamoDbTemplateTest {
         assertEquals(1, queryRequest.getKeyConditions().get("stringProperty").getAttributeValueList().size());
         assertEquals(new AttributeValue(stringProperty),
                 queryRequest.getKeyConditions().get("stringProperty").getAttributeValueList().get(0));
-        assertEquals(maxPageSize, queryRequest.getLimit());
+        assertEquals(maxPageSize, queryRequest.getLimit().intValue());
         assertNotNull(returnedItems);
         assertEquals(1, returnedItems.size());
     }

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDbTemplateTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/DynamoDbTemplateTest.java
@@ -171,8 +171,8 @@ public class DynamoDbTemplateTest {
         assertEquals(1, queryRequest.getKeyConditions().size());
         assertEquals("EQ", queryRequest.getKeyConditions().get("id").getComparisonOperator());
         assertEquals(1, queryRequest.getKeyConditions().get("id").getAttributeValueList().size());
-        assertEquals(new AttributeValue(stringProperty), queryRequest.getKeyConditions().get("id")
-                .getAttributeValueList().get(0));
+        assertEquals(new AttributeValue(stringProperty),
+                queryRequest.getKeyConditions().get("id").getAttributeValueList().get(0));
         assertNotNull(returnedItems);
         assertEquals(1, returnedItems.size());
     }
@@ -216,8 +216,56 @@ public class DynamoDbTemplateTest {
         assertEquals(1, queryRequest.getKeyConditions().size());
         assertEquals("EQ", queryRequest.getKeyConditions().get("stringProperty").getComparisonOperator());
         assertEquals(1, queryRequest.getKeyConditions().get("stringProperty").getAttributeValueList().size());
-        assertEquals(new AttributeValue(stringProperty), queryRequest.getKeyConditions().get("stringProperty")
-                .getAttributeValueList().get(0));
+        assertEquals(new AttributeValue(stringProperty),
+                queryRequest.getKeyConditions().get("stringProperty").getAttributeValueList().get(0));
+        assertEquals(null, queryRequest.getLimit());
+        assertNotNull(returnedItems);
+        assertEquals(1, returnedItems.size());
+    }
+
+    @Test
+    public void shouldFetch_withAttributeQueryOnIndexWithMaxPageSizeSet() throws Exception {
+        // Given
+        final Integer maxPageSize = Randoms.randomIntInRange(1, 100);
+        final AttributeQuery query = mock(AttributeQuery.class);
+        final Condition mockCondition = mock(Condition.class);
+        when(mockCondition.getComparisonOperator()).thenReturn(Operators.EQUALS);
+        final String itemId = randomId();
+        final String stringProperty = randomString(10);
+        final Set<String> stringPropertyValues = new HashSet<>(Arrays.asList(stringProperty));
+        when(mockCondition.getValues()).thenReturn(stringPropertyValues);
+        when(query.getAttributeName()).thenReturn("stringProperty");
+        when(query.getCondition()).thenReturn(mockCondition);
+        final ItemConfiguration itemConfiguration = new ItemConfiguration(StubItem.class, tableName);
+        itemConfiguration.registerIndexes(Arrays.asList(new IndexDefinition("stringProperty")));
+        final Collection<ItemConfiguration> itemConfigurations = Arrays.asList(itemConfiguration);
+        when(mockDatabaseSchemaHolder.itemConfigurations()).thenReturn(itemConfigurations);
+        final DynamoDbTemplate dynamoDbTemplate = new DynamoDbTemplate(mockDatabaseSchemaHolder);
+        final QueryResult mockQueryResult = mock(QueryResult.class);
+        final Map<String, AttributeValue> mockItem = new HashMap<>();
+        mockItem.put("id", new AttributeValue(itemId));
+        mockItem.put("stringProperty", new AttributeValue(stringProperty));
+        final List<Map<String, AttributeValue>> mockItems = Arrays.asList(mockItem);
+        when(mockQueryResult.getItems()).thenReturn(mockItems);
+        when(mockQueryResult.getLastEvaluatedKey()).thenReturn(null);
+        when(mockAmazonDynamoDbClient.query(any(QueryRequest.class))).thenReturn(mockQueryResult);
+        dynamoDbTemplate.initialize(mockAmazonDynamoDbClient);
+
+        // When
+        final Collection<StubItem> returnedItems = dynamoDbTemplate.fetch(query, StubItem.class, maxPageSize);
+
+        // Then
+        final ArgumentCaptor<QueryRequest> queryRequestArgumentCaptor = ArgumentCaptor.forClass(QueryRequest.class);
+        verify(mockAmazonDynamoDbClient).query(queryRequestArgumentCaptor.capture());
+        final QueryRequest queryRequest = queryRequestArgumentCaptor.getValue();
+        assertEquals(schemaName + "." + tableName, queryRequest.getTableName());
+        assertEquals("stringProperty_idx", queryRequest.getIndexName());
+        assertEquals(1, queryRequest.getKeyConditions().size());
+        assertEquals("EQ", queryRequest.getKeyConditions().get("stringProperty").getComparisonOperator());
+        assertEquals(1, queryRequest.getKeyConditions().get("stringProperty").getAttributeValueList().size());
+        assertEquals(new AttributeValue(stringProperty),
+                queryRequest.getKeyConditions().get("stringProperty").getAttributeValueList().get(0));
+        assertEquals(maxPageSize, queryRequest.getLimit());
         assertNotNull(returnedItems);
         assertEquals(1, returnedItems.size());
     }
@@ -260,8 +308,8 @@ public class DynamoDbTemplateTest {
         assertEquals(1, queryRequest.getKeyConditions().size());
         assertEquals("EQ", queryRequest.getKeyConditions().get("id").getComparisonOperator());
         assertEquals(1, queryRequest.getKeyConditions().get("id").getAttributeValueList().size());
-        assertEquals(new AttributeValue(stringProperty), queryRequest.getKeyConditions().get("id")
-                .getAttributeValueList().get(0));
+        assertEquals(new AttributeValue(stringProperty),
+                queryRequest.getKeyConditions().get("id").getAttributeValueList().get(0));
     }
 
     @Test
@@ -305,8 +353,8 @@ public class DynamoDbTemplateTest {
         stubItem.setId(randomId());
         final String stringPropertyValue = randomString(10);
         stubItem.setStringProperty(stringPropertyValue);
-        when(mockAmazonDynamoDbClient.putItem(any(PutItemRequest.class))).thenThrow(
-                ConditionalCheckFailedException.class);
+        when(mockAmazonDynamoDbClient.putItem(any(PutItemRequest.class)))
+                .thenThrow(ConditionalCheckFailedException.class);
 
         // When
         ItemConstraintViolationException actualException = null;
@@ -370,8 +418,8 @@ public class DynamoDbTemplateTest {
         final DynamoDbTemplate dynamoDbTemplate = new DynamoDbTemplate(mockDatabaseSchemaHolder);
         final AmazonDynamoDB mockAmazonDynamoDbClient = mock(AmazonDynamoDB.class);
         dynamoDbTemplate.initialize(mockAmazonDynamoDbClient);
-        when(mockAmazonDynamoDbClient.putItem(any(PutItemRequest.class))).thenThrow(
-                ConditionalCheckFailedException.class);
+        when(mockAmazonDynamoDbClient.putItem(any(PutItemRequest.class)))
+                .thenThrow(ConditionalCheckFailedException.class);
         final StubItem stubItem = new StubItem();
         stubItem.setId(randomId());
         final String stringPropertyValue = randomString(10);
@@ -410,8 +458,8 @@ public class DynamoDbTemplateTest {
         final DynamoDbTemplate dynamoDbTemplate = new DynamoDbTemplate(mockDatabaseSchemaHolder);
         final AmazonDynamoDB mockAmazonDynamoDbClient = mock(AmazonDynamoDB.class);
         dynamoDbTemplate.initialize(mockAmazonDynamoDbClient);
-        when(mockAmazonDynamoDbClient.putItem(any(PutItemRequest.class))).thenThrow(
-                ConditionalCheckFailedException.class);
+        when(mockAmazonDynamoDbClient.putItem(any(PutItemRequest.class)))
+                .thenThrow(ConditionalCheckFailedException.class);
         final StubItem stubItem = new StubItem();
         stubItem.setId(randomId());
         final String stringPropertyValue = randomString(10);
@@ -450,8 +498,8 @@ public class DynamoDbTemplateTest {
         final DynamoDbTemplate dynamoDbTemplate = new DynamoDbTemplate(mockDatabaseSchemaHolder);
         final AmazonDynamoDB mockAmazonDynamoDbClient = mock(AmazonDynamoDB.class);
         dynamoDbTemplate.initialize(mockAmazonDynamoDbClient);
-        when(mockAmazonDynamoDbClient.putItem(any(PutItemRequest.class))).thenReturn(null).thenThrow(
-                AmazonServiceException.class);
+        when(mockAmazonDynamoDbClient.putItem(any(PutItemRequest.class))).thenReturn(null)
+                .thenThrow(AmazonServiceException.class);
         final StubItem stubItem = new StubItem();
         stubItem.setId(randomId());
         final String stringPropertyValue = randomString(10);
@@ -527,9 +575,9 @@ public class DynamoDbTemplateTest {
         assertEquals(key, updateItemRequest.getKey());
         assertEquals(updateItemRequest.getAttributeUpdates().size(), 5);
         assertEquals(
-                new AttributeValueUpdate().withAction(AttributeAction.PUT).withValue(
-                        new AttributeValue(stringPropertyValue)),
-                        updateItemRequest.getAttributeUpdates().get("stringProperty"));
+                new AttributeValueUpdate().withAction(AttributeAction.PUT)
+                        .withValue(new AttributeValue(stringPropertyValue)),
+                updateItemRequest.getAttributeUpdates().get("stringProperty"));
         assertEquals(new ExpectedAttributeValue(new AttributeValue().withN(String.valueOf(oldVersion))),
                 updateItemRequest.getExpected().get("version"));
     }
@@ -549,8 +597,8 @@ public class DynamoDbTemplateTest {
         stubItem.setStringProperty(stringPropertyValue);
         final Long oldVersion = randomLong();
         stubItem.setVersion(oldVersion);
-        when(mockAmazonDynamoDbClient.updateItem(any(UpdateItemRequest.class))).thenThrow(
-                ConditionalCheckFailedException.class);
+        when(mockAmazonDynamoDbClient.updateItem(any(UpdateItemRequest.class)))
+                .thenThrow(ConditionalCheckFailedException.class);
 
         // When
         OptimisticLockException actualException = null;
@@ -626,9 +674,9 @@ public class DynamoDbTemplateTest {
         assertEquals(key, updateItemRequest.getKey());
         assertEquals(updateItemRequest.getAttributeUpdates().size(), 4);
         assertEquals(
-                new AttributeValueUpdate().withAction(AttributeAction.PUT).withValue(
-                        new AttributeValue(stubItem.getStringProperty2())), updateItemRequest.getAttributeUpdates()
-                        .get("stringProperty2"));
+                new AttributeValueUpdate().withAction(AttributeAction.PUT)
+                        .withValue(new AttributeValue(stubItem.getStringProperty2())),
+                updateItemRequest.getAttributeUpdates().get("stringProperty2"));
         assertEquals(new ExpectedAttributeValue(new AttributeValue().withN(String.valueOf(oldVersion))),
                 updateItemRequest.getExpected().get("version"));
     }
@@ -692,9 +740,9 @@ public class DynamoDbTemplateTest {
         assertEquals(key, updateItemRequest.getKey());
         assertEquals(updateItemRequest.getAttributeUpdates().size(), 5);
         assertEquals(
-                new AttributeValueUpdate().withAction(AttributeAction.PUT).withValue(
-                        new AttributeValue(stringPropertyValue)),
-                        updateItemRequest.getAttributeUpdates().get("stringProperty"));
+                new AttributeValueUpdate().withAction(AttributeAction.PUT)
+                        .withValue(new AttributeValue(stringPropertyValue)),
+                updateItemRequest.getAttributeUpdates().get("stringProperty"));
         assertEquals(new ExpectedAttributeValue(new AttributeValue().withN(String.valueOf(oldVersion))),
                 updateItemRequest.getExpected().get("version"));
 
@@ -762,9 +810,9 @@ public class DynamoDbTemplateTest {
         assertEquals(key, updateItemRequest.getKey());
         assertEquals(updateItemRequest.getAttributeUpdates().size(), 5);
         assertEquals(
-                new AttributeValueUpdate().withAction(AttributeAction.PUT).withValue(
-                        new AttributeValue(stringPropertyValue)),
-                        updateItemRequest.getAttributeUpdates().get("stringProperty"));
+                new AttributeValueUpdate().withAction(AttributeAction.PUT)
+                        .withValue(new AttributeValue(stringPropertyValue)),
+                updateItemRequest.getAttributeUpdates().get("stringProperty"));
         assertEquals(new ExpectedAttributeValue(new AttributeValue().withN(String.valueOf(oldVersion))),
                 updateItemRequest.getExpected().get("version"));
     }
@@ -817,8 +865,8 @@ public class DynamoDbTemplateTest {
         key.put("id", new AttributeValue(stubItem.getId()));
         assertEquals(key, updateItemRequest.getKey());
         assertEquals(updateItemRequest.getAttributeUpdates().size(), 5);
-        assertEquals(new AttributeValueUpdate().withAction(AttributeAction.DELETE), updateItemRequest
-                .getAttributeUpdates().get("stringProperty"));
+        assertEquals(new AttributeValueUpdate().withAction(AttributeAction.DELETE),
+                updateItemRequest.getAttributeUpdates().get("stringProperty"));
         assertEquals(new ExpectedAttributeValue(new AttributeValue().withN(String.valueOf(oldVersion))),
                 updateItemRequest.getExpected().get("version"));
 
@@ -896,9 +944,9 @@ public class DynamoDbTemplateTest {
         assertEquals(key, updateItemRequest.getKey());
         assertEquals(updateItemRequest.getAttributeUpdates().size(), 5);
         assertEquals(
-                new AttributeValueUpdate().withAction(AttributeAction.PUT).withValue(
-                        new AttributeValue(newStringPropertyValue)),
-                        updateItemRequest.getAttributeUpdates().get("stringProperty"));
+                new AttributeValueUpdate().withAction(AttributeAction.PUT)
+                        .withValue(new AttributeValue(newStringPropertyValue)),
+                updateItemRequest.getAttributeUpdates().get("stringProperty"));
         assertEquals(new ExpectedAttributeValue(new AttributeValue().withN(String.valueOf(oldVersion))),
                 updateItemRequest.getExpected().get("version"));
 
@@ -906,7 +954,8 @@ public class DynamoDbTemplateTest {
         assertEquals(schemaName + "-indexes." + tableName, deleteIndexRequest.getTableName());
         assertEquals(2, deleteIndexRequest.getKey().size());
         assertEquals(new AttributeValue("stringProperty"), deleteIndexRequest.getKey().get("property"));
-        assertEquals(new AttributeValue(newStringPropertyValue.toUpperCase()), deleteIndexRequest.getKey().get("value"));
+        assertEquals(new AttributeValue(newStringPropertyValue.toUpperCase()),
+                deleteIndexRequest.getKey().get("value"));
 
         assertNotNull(actualException);
     }
@@ -956,9 +1005,9 @@ public class DynamoDbTemplateTest {
         assertEquals(key, updateItemRequest.getKey());
         assertEquals(updateItemRequest.getAttributeUpdates().size(), 5);
         assertEquals(
-                new AttributeValueUpdate().withAction(AttributeAction.PUT).withValue(
-                        new AttributeValue(stringPropertyValue)),
-                        updateItemRequest.getAttributeUpdates().get("stringProperty"));
+                new AttributeValueUpdate().withAction(AttributeAction.PUT)
+                        .withValue(new AttributeValue(stringPropertyValue)),
+                updateItemRequest.getAttributeUpdates().get("stringProperty"));
         assertEquals(new ExpectedAttributeValue(new AttributeValue().withN(String.valueOf(oldVersion))),
                 updateItemRequest.getExpected().get("version"));
     }
@@ -1008,9 +1057,9 @@ public class DynamoDbTemplateTest {
         assertEquals(key, updateItemRequest.getKey());
         assertEquals(updateItemRequest.getAttributeUpdates().size(), 5);
         assertEquals(
-                new AttributeValueUpdate().withAction(AttributeAction.PUT).withValue(
-                        new AttributeValue(stringPropertyValue)),
-                        updateItemRequest.getAttributeUpdates().get("stringProperty"));
+                new AttributeValueUpdate().withAction(AttributeAction.PUT)
+                        .withValue(new AttributeValue(stringPropertyValue)),
+                updateItemRequest.getAttributeUpdates().get("stringProperty"));
         assertEquals(new ExpectedAttributeValue(new AttributeValue().withN(String.valueOf(oldVersion))),
                 updateItemRequest.getExpected().get("version"));
     }
@@ -1104,7 +1153,8 @@ public class DynamoDbTemplateTest {
         assertEquals(schemaName + "." + tableName, deleteItemRequest.getTableName());
         assertEquals(2, deleteItemRequest.getKey().size());
         assertEquals(new AttributeValue(stubItem.getId()), deleteItemRequest.getKey().get("id"));
-        assertEquals(new AttributeValue(stubItem.getStringProperty()), deleteItemRequest.getKey().get("stringProperty"));
+        assertEquals(new AttributeValue(stubItem.getStringProperty()),
+                deleteItemRequest.getKey().get("stringProperty"));
         assertEquals(new ExpectedAttributeValue(new AttributeValue().withN(String.valueOf(stubItem.getVersion()))),
                 deleteItemRequest.getExpected().get("version"));
     }
@@ -1438,8 +1488,8 @@ public class DynamoDbTemplateTest {
         final AmazonDynamoDB mockAmazonDynamoDbClient = mock(AmazonDynamoDB.class);
         dynamoDbTemplate.initialize(mockAmazonDynamoDbClient);
 
-        when(mockAmazonDynamoDbClient.batchWriteItem(any(BatchWriteItemRequest.class))).thenThrow(
-                AmazonServiceException.class);
+        when(mockAmazonDynamoDbClient.batchWriteItem(any(BatchWriteItemRequest.class)))
+                .thenThrow(AmazonServiceException.class);
         final List<StubItem> stubItems = new ArrayList<StubItem>();
         for (int i = 0; i < numberOfItems; i++) {
             final StubItem stubItem = new StubItem();

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbTemplateIntegrationTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbTemplateIntegrationTest.java
@@ -437,7 +437,7 @@ public class DynamoDbTemplateIntegrationTest {
         dynamoDbTemplate.initialize(amazonDynamoDbClient);
 
         // When
-        final Collection<StubItem> itemResults = dynamoDbTemplate.fetch(query, StubItem.class, 10);
+        final Collection<StubItem> itemResults = dynamoDbTemplate.fetch(query, StubItem.class, Randoms.randomInt(11));
 
         // Then
         assertNotNull(itemResults);

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbTemplateIntegrationTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/dynamodb/integration/DynamoDbTemplateIntegrationTest.java
@@ -55,8 +55,8 @@ public class DynamoDbTemplateIntegrationTest {
 
     @BeforeClass
     public static void createTables() throws Exception {
-        amazonDynamoDbClient = new AmazonDynamoDBClient(new BasicAWSCredentials(AwsIntegration.getAccessKeyId(),
-                AwsIntegration.getSecretKeyId()));
+        amazonDynamoDbClient = new AmazonDynamoDBClient(
+                new BasicAWSCredentials(AwsIntegration.getAccessKeyId(), AwsIntegration.getSecretKeyId()));
         amazonDynamoDbClient.setEndpoint(AwsIntegration.getDynamoDbEndpoint());
         dataGenerator = new DynamoDbDataGenerator(amazonDynamoDbClient);
 
@@ -426,6 +426,26 @@ public class DynamoDbTemplateIntegrationTest {
     }
 
     @Test
+    public void shouldFetch_withAttributeQueryAndMaxPageSize() throws Exception {
+        // Given
+        final StubItem createdItem = dataGenerator.createStubItem();
+        final String stringProperty = createdItem.getStringProperty();
+        final StubItem stubItem = new StubItem();
+        stubItem.setStringProperty(stringProperty);
+        final Query query = new AttributeQuery(STRING_PROPERTY, new Condition(Operators.EQUALS, stringProperty));
+        final DynamoDbTemplate dynamoDbTemplate = new DynamoDbTemplate(databaseSchemaHolder);
+        dynamoDbTemplate.initialize(amazonDynamoDbClient);
+
+        // When
+        final Collection<StubItem> itemResults = dynamoDbTemplate.fetch(query, StubItem.class, 10);
+
+        // Then
+        assertNotNull(itemResults);
+        assertEquals(1, itemResults.size());
+        assertEquals(createdItem, itemResults.iterator().next());
+    }
+
+    @Test
     public void shouldGetEmptySet_withNullAttributeQuery() {
         // Given
         final String stringProperty = null;
@@ -562,8 +582,8 @@ public class DynamoDbTemplateIntegrationTest {
         // Then
         final Map<String, AttributeValue> key = new HashMap<>();
         key.put("id", new AttributeValue(createdItem.getId()));
-        final GetItemResult result = amazonDynamoDbClient.getItem(dataGenerator.getUnitTestSchemaName() + "."
-                + dataGenerator.getStubItemTableName(), key);
+        final GetItemResult result = amazonDynamoDbClient
+                .getItem(dataGenerator.getUnitTestSchemaName() + "." + dataGenerator.getStubItemTableName(), key);
         assertNull(result.getItem());
     }
 
@@ -581,8 +601,8 @@ public class DynamoDbTemplateIntegrationTest {
         final Map<String, AttributeValue> key = new HashMap<>();
         key.put("id", new AttributeValue(createdItem.getId()));
         key.put("supportingId", new AttributeValue(createdItem.getSupportingId()));
-        final GetItemResult result = amazonDynamoDbClient.getItem(dataGenerator.getUnitTestSchemaName() + "."
-                + dataGenerator.getStubItemWithRangeTableName(), key);
+        final GetItemResult result = amazonDynamoDbClient.getItem(
+                dataGenerator.getUnitTestSchemaName() + "." + dataGenerator.getStubItemWithRangeTableName(), key);
         assertNull(result.getItem());
     }
 

--- a/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/database/InMemoryDatabaseTemplate.java
+++ b/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/database/InMemoryDatabaseTemplate.java
@@ -67,7 +67,8 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
     }
 
     @Override
-    public <T extends Item> T create(final T item, final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
+    public <T extends Item> T create(final T item,
+            final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
         final ItemId itemId = getItemId(item);
         final String tableName = getItemTableName(item.getClass());
         final SerializedItem oldSerializedItem = getItemMap(tableName).get(itemId);
@@ -83,7 +84,8 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends Item> T update(final T item, final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
+    public <T extends Item> T update(final T item,
+            final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
         final ItemId itemId = getItemId(item);
         final Class<? extends Item> itemType = item.getClass();
         final String tableName = getItemTableName(itemType);
@@ -93,8 +95,8 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
         }
         final T oldItem = (T) oldSerializedItem.getEntity(item.getClass());
         if (!item.getVersion().equals(oldItem.getVersion())) {
-            throw new IllegalAccessError("Expected version [" + item.getVersion() + "] but was ["
-                    + oldItem.getVersion() + "]");
+            throw new IllegalAccessError(
+                    "Expected version [" + item.getVersion() + "] but was [" + oldItem.getVersion() + "]");
         }
         deleteUniqueConstraints(oldItem);
         try {
@@ -177,7 +179,7 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
 
     /**
      * Checks the presence of a matching unique constraint for the given item property
-     * 
+     *
      * @param item The Item for which to check unique constraints
      * @param propertyName The name of the property for which the unique constraint should be checked
      * @param propertyValue The value of the property which needs to be checked for presence of unique constraint
@@ -186,8 +188,8 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
     boolean hasMatchingUniqueConstraint(final Item item, final String propertyName, final String propertyValue) {
         final Class<? extends Item> itemClass = item.getClass();
         final String tableName = getItemTableName(itemClass);
-        final Map<String, ItemId> uniqueConstraintsForProperty = uniqueConstraints.get(newUniqueConstraintKey(
-                tableName, propertyName));
+        final Map<String, ItemId> uniqueConstraintsForProperty = uniqueConstraints
+                .get(newUniqueConstraintKey(tableName, propertyName));
         final ItemId itemId = getItemId(item);
         for (final Entry<String, ItemId> entry : uniqueConstraintsForProperty.entrySet()) {
             if (entry.getValue().equals(itemId)) {
@@ -206,6 +208,12 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
         } else {
             throw new UnsupportedQueryException(query.getClass());
         }
+    }
+
+    @Override
+    public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass,
+            final Integer maxPageSize) {
+        return fetch(query, itemClass);
     }
 
     @Override
@@ -320,8 +328,8 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
                         break;
                 }
             } catch (final Exception e) {
-                throw new IllegalStateException("No getter for property [" + attribute + "] on class: ["
-                        + item.getClass() + "]");
+                throw new IllegalStateException(
+                        "No getter for property [" + attribute + "] on class: [" + item.getClass() + "]");
             }
 
         }
@@ -357,5 +365,4 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
             entry.setValue(new HashMap<String, ItemId>());
         }
     }
-
 }

--- a/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/database/InMemoryDatabaseTemplate.java
+++ b/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/database/InMemoryDatabaseTemplate.java
@@ -211,8 +211,7 @@ public class InMemoryDatabaseTemplate extends AbstractDatabaseTemplate implement
     }
 
     @Override
-    public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass,
-            final Integer maxPageSize) {
+    public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass, final int maxPageSize) {
         return fetch(query, itemClass);
     }
 

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/DatabaseTemplate.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/DatabaseTemplate.java
@@ -42,6 +42,8 @@ public interface DatabaseTemplate {
 
     <T extends Item> Collection<T> fetch(final Query query, Class<T> itemClass);
 
+    <T extends Item> Collection<T> fetch(final Query query, Class<T> itemClass, Integer maxPageSize);
+
     <T extends Item> T fetchUnique(final Query query, Class<T> itemClass) throws NonUniqueResultException;
 
     GeneratedKeyHolder generateKeys(SequenceKeyGenerator sequenceKeyGenerator);

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/DatabaseTemplate.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/DatabaseTemplate.java
@@ -42,7 +42,7 @@ public interface DatabaseTemplate {
 
     <T extends Item> Collection<T> fetch(final Query query, Class<T> itemClass);
 
-    <T extends Item> Collection<T> fetch(final Query query, Class<T> itemClass, Integer maxPageSize);
+    <T extends Item> Collection<T> fetch(final Query query, Class<T> itemClass, int maxPageSize);
 
     <T extends Item> T fetchUnique(final Query query, Class<T> itemClass) throws NonUniqueResultException;
 

--- a/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/database/AbstractDatabaseTemplateTest.java
+++ b/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/database/AbstractDatabaseTemplateTest.java
@@ -66,7 +66,7 @@ public class AbstractDatabaseTemplateTest {
             @SuppressWarnings("unchecked")
             @Override
             public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass,
-                    final Integer maxPageSize) {
+                    final int maxPageSize) {
                 return (Collection<T>) items;
             }
 
@@ -114,7 +114,7 @@ public class AbstractDatabaseTemplateTest {
             @SuppressWarnings("unchecked")
             @Override
             public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass,
-                    final Integer maxPageSize) {
+                    final int maxPageSize) {
                 return (Collection<T>) items;
             }
 

--- a/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/database/AbstractDatabaseTemplateTest.java
+++ b/cheddar/cheddar-persistence/src/test/java/com/clicktravel/cheddar/infrastructure/persistence/database/AbstractDatabaseTemplateTest.java
@@ -63,6 +63,13 @@ public class AbstractDatabaseTemplateTest {
                 return (Collection<T>) items;
             }
 
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass,
+                    final Integer maxPageSize) {
+                return (Collection<T>) items;
+            }
+
             @Override
             public GeneratedKeyHolder generateKeys(final SequenceKeyGenerator sequenceKeyGenerator) {
                 return null;
@@ -71,7 +78,6 @@ public class AbstractDatabaseTemplateTest {
             @Override
             public void delete(final Item item, final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
             }
-
         };
 
         // When
@@ -105,6 +111,13 @@ public class AbstractDatabaseTemplateTest {
                 return (Collection<T>) items;
             }
 
+            @SuppressWarnings("unchecked")
+            @Override
+            public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass,
+                    final Integer maxPageSize) {
+                return (Collection<T>) items;
+            }
+
             @Override
             public void delete(final Item item, final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
             }
@@ -119,7 +132,6 @@ public class AbstractDatabaseTemplateTest {
             public GeneratedKeyHolder generateKeys(final SequenceKeyGenerator sequenceKeyGenerator) {
                 return null;
             }
-
         };
 
         // When

--- a/cheddar/cheddar-tx/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/tx/TransactionalDatabaseTemplate.java
+++ b/cheddar/cheddar-tx/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/tx/TransactionalDatabaseTemplate.java
@@ -112,8 +112,7 @@ public class TransactionalDatabaseTemplate implements DatabaseTemplate, Transact
     }
 
     @Override
-    public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass,
-            final Integer maxPageSize) {
+    public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass, final int maxPageSize) {
         return databaseTemplate.fetch(query, itemClass, maxPageSize);
     }
 

--- a/cheddar/cheddar-tx/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/tx/TransactionalDatabaseTemplate.java
+++ b/cheddar/cheddar-tx/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/tx/TransactionalDatabaseTemplate.java
@@ -68,13 +68,14 @@ public class TransactionalDatabaseTemplate implements DatabaseTemplate, Transact
             currentTransaction.remove();
             logger.trace("Transaction successfully committed: " + transaction.transactionId());
         } catch (final Throwable e) {
-            throw new TransactionalResourceException("Failed to commit DatabaseTemplate transaction: "
-                    + transaction.transactionId(), e);
+            throw new TransactionalResourceException(
+                    "Failed to commit DatabaseTemplate transaction: " + transaction.transactionId(), e);
         }
     }
 
     @Override
-    public <T extends Item> T create(final T item, final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
+    public <T extends Item> T create(final T item,
+            final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
         final DatabaseTransaction transaction = getCurrentTransaction();
         final List<PersistenceExceptionHandler<?>> persistenceExceptionHandlerList = new ArrayList<PersistenceExceptionHandler<?>>();
         Collections.addAll(persistenceExceptionHandlerList, persistenceExceptionHandlers);
@@ -83,7 +84,8 @@ public class TransactionalDatabaseTemplate implements DatabaseTemplate, Transact
     }
 
     @Override
-    public <T extends Item> T update(final T item, final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
+    public <T extends Item> T update(final T item,
+            final PersistenceExceptionHandler<?>... persistenceExceptionHandlers) {
         final DatabaseTransaction transaction = getCurrentTransaction();
         final List<PersistenceExceptionHandler<?>> persistenceExceptionHandlerList = new ArrayList<PersistenceExceptionHandler<?>>();
         Collections.addAll(persistenceExceptionHandlerList, persistenceExceptionHandlers);
@@ -110,6 +112,12 @@ public class TransactionalDatabaseTemplate implements DatabaseTemplate, Transact
     }
 
     @Override
+    public <T extends Item> Collection<T> fetch(final Query query, final Class<T> itemClass,
+            final Integer maxPageSize) {
+        return databaseTemplate.fetch(query, itemClass, maxPageSize);
+    }
+
+    @Override
     public <T extends Item> T fetchUnique(final Query query, final Class<T> itemClass) throws NonUniqueResultException {
         return databaseTemplate.fetchUnique(query, itemClass);
     }
@@ -123,5 +131,4 @@ public class TransactionalDatabaseTemplate implements DatabaseTemplate, Transact
     public void abort() throws TransactionException {
         currentTransaction.remove();
     }
-
 }


### PR DESCRIPTION
This commit adds the ability to set a maximum page size that DynamoDB will use when reading data, this will allow me to run tests on UAT to confirm whether changing the max page size will have the desired impact on reducing read throughputs.

Signed-off-by: Craig Handley <craig.handley@clicktravel.com>

the-cheddar-chapter@clicktravel.com - please review