### PR TITLE
Trim logging dependencies to API only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,17 +62,6 @@ configure(subproj) {
 
         // Remove Jakarta Commons Logging
         exclude(group: 'commons-logging', module: 'commons-logging')
-
-        // Add logging dependencies
-        dependencies {
-            compile 'org.slf4j:slf4j-api:1.7.5'
-            compile 'org.slf4j:jcl-over-slf4j:1.7.5'
-            runtime 'org.slf4j:jul-to-slf4j:1.7.5'
-            runtime 'org.slf4j:slf4j-log4j12:1.7.5'
-            runtime 'log4j:log4j:1.2.17'
-            runtime 'log4j:apache-log4j-extras:1.2.17'
-            runtime 'com.logentries:logentries-appender:1.1.18'
-        }
     }
 
     task sourcesJar(type: Jar, dependsOn: classes) {

--- a/cheddar/cheddar-application/build.gradle
+++ b/cheddar/cheddar-application/build.gradle
@@ -1,4 +1,5 @@
 apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
 
 def springVersion = '4.1.1.RELEASE'
 

--- a/cheddar/cheddar-domain/build.gradle
+++ b/cheddar/cheddar-domain/build.gradle
@@ -1,8 +1,7 @@
 apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
 
 dependencies {
     compile project(':commons:commons-lang')
     compile project(':cheddar:cheddar-events')
-  
-    compile 'org.slf4j:slf4j-api:1.7.5'
 }

--- a/cheddar/cheddar-events/build.gradle
+++ b/cheddar/cheddar-events/build.gradle
@@ -1,11 +1,10 @@
+apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
+
 def springVersion = '4.1.1.RELEASE'
 
 dependencies {
     compile project(':cheddar:cheddar-messaging')
     compile 'com.fasterxml.jackson.core:jackson-databind:2.2.2'
     compile "org.springframework:spring-context-support:${springVersion}"   //Required for BeanUtils
-
-    testCompile project(':commons:commons-lang')
-    testCompile 'junit:junit:4.11'
-    testCompile 'org.mockito:mockito-core:1.9.5'
 }

--- a/cheddar/cheddar-integration-aws/build.gradle
+++ b/cheddar/cheddar-integration-aws/build.gradle
@@ -1,4 +1,5 @@
 apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
 
 def springVersion = '4.1.1.RELEASE'
 
@@ -24,9 +25,7 @@ dependencies {
     compile 'javax.mail:mail:1.4.7'
     compile 'joda-time:joda-time:2.8.2'
     compile 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.4.0'
-    compile 'org.slf4j:slf4j-api:1.7.5'
-    compile 'org.slf4j:jcl-over-slf4j:1.7.5'    //Required for AWS SDK
-    compile 'net.spy:spymemcached:2.11.4' //USED to connect to memcache nodes - the aws version of this file is not in a public repo
+    compile 'net.spy:spymemcached:2.11.4' // Used to connect to memcache nodes - the aws version of this file is not in a public repo
 }
 
 test {

--- a/cheddar/cheddar-integration-mocks/build.gradle
+++ b/cheddar/cheddar-integration-mocks/build.gradle
@@ -1,4 +1,5 @@
 apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
 
 def springVersion = '4.1.1.RELEASE'
 
@@ -10,6 +11,5 @@ dependencies {
 
     compile "org.springframework:spring-context:${springVersion}"
     compile 'com.thoughtworks.xstream:xstream:1.4.8'
-    compile 'org.slf4j:slf4j-api:1.7.5'
 }
 

--- a/cheddar/cheddar-messaging/build.gradle
+++ b/cheddar/cheddar-messaging/build.gradle
@@ -1,13 +1,10 @@
+apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
+
 def springVersion = '4.1.1.RELEASE'
 
 dependencies {
     compile "org.springframework:spring-context:${springVersion}"
-
     compile project(':commons:commons-lang')
-    testCompile 'junit:junit:4.11'
-    testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.powermock:powermock-api-mockito:1.5.1'
-    testCompile 'org.powermock:powermock-module-junit4:1.5.1'
 }
 

--- a/cheddar/cheddar-metrics-intercom/build.gradle
+++ b/cheddar/cheddar-metrics-intercom/build.gradle
@@ -1,4 +1,4 @@
-apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
 
 dependencies {
     compile project(':cheddar:cheddar-metrics')

--- a/cheddar/cheddar-metrics/build.gradle
+++ b/cheddar/cheddar-metrics/build.gradle
@@ -1,7 +1,4 @@
-apply from: '../../test.gradle'
-
 dependencies {
 	compile 'io.intercom:intercom-java:1.1.1'
 	compile 'joda-time:joda-time:2.8.2'
-
 }

--- a/cheddar/cheddar-persisted-trackers/build.gradle
+++ b/cheddar/cheddar-persisted-trackers/build.gradle
@@ -1,3 +1,5 @@
+apply from: '../../logging-api.gradle'
+
 dependencies {
 	compile project(':cheddar:cheddar-persistence')
 	compile project(':cheddar:cheddar-application')

--- a/cheddar/cheddar-persistence/build.gradle
+++ b/cheddar/cheddar-persistence/build.gradle
@@ -1,7 +1,5 @@
+apply from: '../../test.gradle'
+
 dependencies {
     compile project(':commons:commons-lang')
-    
-    testCompile 'junit:junit:4.11'
-    testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }

--- a/cheddar/cheddar-rest/build.gradle
+++ b/cheddar/cheddar-rest/build.gradle
@@ -12,5 +12,4 @@ dependencies {
     compile "org.glassfish.jersey.core:jersey-server:${jerseyVersion}"
     compile "org.glassfish.jersey.media:jersey-media-moxy:${jerseyVersion}"
     compile "org.glassfish.jersey.media:jersey-media-multipart:${jerseyVersion}"
-    compile 'org.slf4j:slf4j-api:1.7.5'
 }

--- a/cheddar/cheddar-server/build.gradle
+++ b/cheddar/cheddar-server/build.gradle
@@ -1,4 +1,5 @@
 apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
 
 def jerseyVersion = '2.15'
 

--- a/cheddar/cheddar-system-events/build.gradle
+++ b/cheddar/cheddar-system-events/build.gradle
@@ -1,4 +1,5 @@
 apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
 
 dependencies {
     compile project(':cheddar:cheddar-events')

--- a/cheddar/cheddar-tx-api/build.gradle
+++ b/cheddar/cheddar-tx-api/build.gradle
@@ -1,5 +1,3 @@
-apply from: '../../test.gradle'
-
 def springVersion = '4.1.1.RELEASE'
 
 dependencies {

--- a/cheddar/cheddar-tx/build.gradle
+++ b/cheddar/cheddar-tx/build.gradle
@@ -1,4 +1,5 @@
 apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
 
 dependencies {
     compile project(':cheddar:cheddar-tx-api')

--- a/commons/commons-httpclient/build.gradle
+++ b/commons/commons-httpclient/build.gradle
@@ -1,3 +1,6 @@
+apply from: '../../test.gradle'
+apply from: '../../logging-api.gradle'
+
 def jerseyVersion = '2.15'
 
 dependencies {
@@ -6,9 +9,5 @@ dependencies {
     compile "org.glassfish.jersey.core:jersey-client:$jerseyVersion"
     compile "org.glassfish.jersey.media:jersey-media-multipart:$jerseyVersion"
     compile "org.glassfish.jersey.media:jersey-media-moxy:$jerseyVersion"
-    compile 'org.slf4j:slf4j-api:1.7.5'
-    
     compile "org.glassfish.jersey.security:oauth2-client:$jerseyVersion"
-    
-    testCompile 'junit:junit:4.11'
 }

--- a/commons/commons-lang/build.gradle
+++ b/commons/commons-lang/build.gradle
@@ -1,10 +1,6 @@
+apply from: '../../test.gradle'
+
 dependencies {
     compile 'joda-time:joda-time:2.8.2'
     compile 'javax.mail:mail:1.4.7'
-    
-    testCompile 'junit:junit:4.11'
-    testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.powermock:powermock-api-mockito:1.5.1'
-    testCompile 'org.powermock:powermock-module-junit4:1.5.1'
 }

--- a/commons/commons-test/build.gradle
+++ b/commons/commons-test/build.gradle
@@ -1,9 +1,6 @@
 apply from: '../../test.gradle'
 
-def springVersion = '4.1.1.RELEASE'
-
 dependencies {
+    compile 'org.powermock:powermock-api-mockito:1.6.3'
     compile project(':commons:commons-lang')
-
-    compile 'org.mockito:mockito-core:1.9.5'
 }

--- a/logging-api.gradle
+++ b/logging-api.gradle
@@ -1,0 +1,5 @@
+dependencies {
+    compile 'org.slf4j:slf4j-api:1.7.5'
+    compile 'org.slf4j:jcl-over-slf4j:1.7.5'
+    compile 'org.slf4j:jul-to-slf4j:1.7.5'
+}

--- a/test.gradle
+++ b/test.gradle
@@ -1,8 +1,7 @@
 dependencies {
-    testCompile 'junit:junit:4.11'
-    testCompile 'org.mockito:mockito-core:1.9.5'
+    testCompile 'junit:junit:4.12'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'org.powermock:powermock-api-mockito:1.5.1'
-    testCompile 'org.powermock:powermock-module-junit4:1.5.1'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.3'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.3'
     testCompile project(':commons:commons-lang')
 }


### PR DESCRIPTION
- Only SLF4J API and bridge dependencies are needed. The logging implementation choice should be left to the application.
- DRY test and logging dependencies

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>