### PR TITLE
FC-102 Upgrade to Jersey 2.22.1 and Gradle 2.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,4 +111,4 @@ task checkAndUploadAll { dependsOn { [checkAllWithIntegrationIfNeeded, uploadAll
 uploadAll.mustRunAfter checkAllWithIntegrationIfNeeded
 
 // Produce Gradle Wrapper scripts for running Gradle on machines that don't have Gradle installed
-task wrapper(type: Wrapper) { gradleVersion = '2.3' }
+task wrapper(type: Wrapper) { gradleVersion = '2.9' }

--- a/cheddar/cheddar-rest/build.gradle
+++ b/cheddar/cheddar-rest/build.gradle
@@ -1,6 +1,6 @@
 apply from: '../../test.gradle'
 
-def jerseyVersion = '2.15'
+def jerseyVersion = '2.22.1'
 
 dependencies {
     compile project(':commons:commons-lang')

--- a/cheddar/cheddar-server/build.gradle
+++ b/cheddar/cheddar-server/build.gradle
@@ -1,7 +1,7 @@
 apply from: '../../test.gradle'
 apply from: '../../logging-api.gradle'
 
-def jerseyVersion = '2.15'
+def jerseyVersion = '2.22.1'
 
 dependencies {
     compile project(':cheddar:cheddar-rest')

--- a/commons/commons-httpclient/build.gradle
+++ b/commons/commons-httpclient/build.gradle
@@ -1,7 +1,7 @@
 apply from: '../../test.gradle'
 apply from: '../../logging-api.gradle'
 
-def jerseyVersion = '2.15'
+def jerseyVersion = '2.22.1'
 
 dependencies {
     compile project(':commons:commons-lang')

--- a/commons/commons-lang/build.gradle
+++ b/commons/commons-lang/build.gradle
@@ -1,6 +1,9 @@
-apply from: '../../test.gradle'
-
 dependencies {
     compile 'joda-time:joda-time:2.8.2'
     compile 'javax.mail:mail:1.4.7'
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.3'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.3'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.9-bin.zip


### PR DESCRIPTION
- Also removed cyclic dependency in commons-lang project

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>