### PR TITLE
Workaround for Eclipse project dependency issues

### DIFF
--- a/cheddar/cheddar-metrics/build.gradle
+++ b/cheddar/cheddar-metrics/build.gradle
@@ -1,4 +1,11 @@
+def jacksonVersion = '2.6.3'
+
 dependencies {
 	compile 'io.intercom:intercom-java:1.1.1'
 	compile 'joda-time:joda-time:2.8.2'
+	
+    // Workaround for Eclipse pulling in older Jackson dependencies
+    runtime "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    runtime "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    runtime "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 }

--- a/commons/commons-httpclient/build.gradle
+++ b/commons/commons-httpclient/build.gradle
@@ -2,6 +2,7 @@ apply from: '../../test.gradle'
 apply from: '../../logging-api.gradle'
 
 def jerseyVersion = '2.22.1'
+def jacksonVersion = '2.6.3'
 
 dependencies {
     compile project(':commons:commons-lang')
@@ -10,4 +11,9 @@ dependencies {
     compile "org.glassfish.jersey.media:jersey-media-multipart:$jerseyVersion"
     compile "org.glassfish.jersey.media:jersey-media-moxy:$jerseyVersion"
     compile "org.glassfish.jersey.security:oauth2-client:$jerseyVersion"
+
+    // Workaround for Eclipse pulling in older Jackson dependencies
+    runtime "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    runtime "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    runtime "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 }


### PR DESCRIPTION
Ensure no old versions of 'jackson-databind' (prior to 2.6.3) are present on any Eclipse project configurations. This works around an issue found in service testing in Eclipse where older versions of 'jackson-databind' are pulled in from certain sub-projects, rather than version 2.6.3 as specified in the top level project.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>