### PR TITLE
DP-161 Enable CloudSearch domain creation to be skipped

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/AmazonCloudSearchDomainClientBuilder.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/AmazonCloudSearchDomainClientBuilder.java
@@ -23,7 +23,8 @@ import com.amazonaws.services.cloudsearchdomain.AmazonCloudSearchDomainClient;
 public class AmazonCloudSearchDomainClientBuilder {
 
     public static AmazonCloudSearchDomain build(final AWSCredentials awsCredentials, final String endpoint) {
-        final AmazonCloudSearchDomain amazonCloudSearchDomain = new AmazonCloudSearchDomainClient(awsCredentials);
+        final AmazonCloudSearchDomain amazonCloudSearchDomain = awsCredentials == null
+                ? new AmazonCloudSearchDomainClient() : new AmazonCloudSearchDomainClient(awsCredentials);
         amazonCloudSearchDomain.setEndpoint(endpoint);
         return amazonCloudSearchDomain;
     }

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/manager/CloudSearchInfrastructureManager.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/manager/CloudSearchInfrastructureManager.java
@@ -16,7 +16,10 @@
  */
 package com.clicktravel.infrastructure.persistence.aws.cloudsearch.manager;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.slf4j.Logger;
@@ -33,8 +36,8 @@ import com.clicktravel.infrastructure.persistence.aws.cloudsearch.CloudSearchEng
 
 /**
  * Amazon Web Services CloudSearch Infrastructure Manager
- *
  */
+@Deprecated
 public class CloudSearchInfrastructureManager {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -104,11 +107,12 @@ public class CloudSearchInfrastructureManager {
         logger.debug("CloudSearch domain created: " + domainName);
         final Collection<IndexField> indexFields = indexDefinitionToIndexFieldCollectionMapper.map(indexDefinitions);
         for (final IndexField indexField : indexFields) {
-            final DefineIndexFieldRequest defineIndexFieldRequest = new DefineIndexFieldRequest().withDomainName(
-                    domainName).withIndexField(indexField);
+            final DefineIndexFieldRequest defineIndexFieldRequest = new DefineIndexFieldRequest()
+                    .withDomainName(domainName).withIndexField(indexField);
             final DefineIndexFieldResult defineIndexFieldResult = cloudSearchClient
                     .defineIndexField(defineIndexFieldRequest);
-            if (OptionState.valueOf(defineIndexFieldResult.getIndexField().getStatus().getState()) != OptionState.RequiresIndexDocuments) {
+            if (OptionState.valueOf(defineIndexFieldResult.getIndexField().getStatus()
+                    .getState()) != OptionState.RequiresIndexDocuments) {
                 throw new IllegalStateException(String.format("Index with name %s failed to be created in domain %s",
                         indexField.getIndexFieldName(), domainName));
             }


### PR DESCRIPTION
- Currently all Cheddar applications using CloudSearch domain(s) will attempt to create the domain if it does not exist. This change enables the domain creation to be optionally skipped. Domain creation in Cheddar is performed by the class CloudSearchInfrastructureManager. Domain creation is now deprecated and in future this class will be removed.
- Added option to use default credentials provider chain when configuring CloudSearch client. This is intended to support use of IAM Roles when accessing AWS resources.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>