### PR TITLE
[FC-105] Log Event objects rather than messages

### DIFF
--- a/cheddar/cheddar-application/src/main/java/com/clicktravel/cheddar/application/pending/result/PendingResultOfferedEvent.java
+++ b/cheddar/cheddar-application/src/main/java/com/clicktravel/cheddar/application/pending/result/PendingResultOfferedEvent.java
@@ -45,7 +45,7 @@ public class PendingResultOfferedEvent extends AbstractSystemEvent {
 
     @Override
     public String toString() {
-        return "PendingResultOfferedEvent [pendingResultId=" + pendingResultId + ", resultXml=" + resultXml + "]";
+        return "PendingResultOfferedEvent [pendingResultId=" + pendingResultId + "]";
     }
 
 }

--- a/cheddar/cheddar-application/src/main/java/com/clicktravel/cheddar/application/pending/result/PendingResultOfferedEvent.java
+++ b/cheddar/cheddar-application/src/main/java/com/clicktravel/cheddar/application/pending/result/PendingResultOfferedEvent.java
@@ -43,4 +43,9 @@ public class PendingResultOfferedEvent extends AbstractSystemEvent {
         this.resultXml = resultXml;
     }
 
+    @Override
+    public String toString() {
+        return "PendingResultOfferedEvent [pendingResultId=" + pendingResultId + ", resultXml=" + resultXml + "]";
+    }
+
 }

--- a/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/AbstractEvent.java
+++ b/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/AbstractEvent.java
@@ -16,8 +16,6 @@
  */
 package com.clicktravel.cheddar.event;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -28,7 +26,6 @@ import com.fasterxml.jackson.datatype.joda.JodaModule;
 public abstract class AbstractEvent implements Event {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    private static Logger logger = LoggerFactory.getLogger(AbstractEvent.class);
 
     static {
         MAPPER.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
@@ -41,13 +38,12 @@ public abstract class AbstractEvent implements Event {
     public abstract String type();
 
     public static <T extends Event> T newEvent(final Class<T> eventClass, final String serializedEvent) {
-        logger.debug("Serialized event: " + serializedEvent);
         try {
             final T event = eventClass.newInstance();
             event.deserializeAndApply(serializedEvent);
             return event;
-        } catch (final Exception e) {
-            throw new IllegalStateException("Cannot build event from serialized form: [" + serializedEvent + "]", e);
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new IllegalStateException("Could not instantiate event " + eventClass.getName());
         }
     }
 
@@ -66,7 +62,7 @@ public abstract class AbstractEvent implements Event {
             final Event event = MAPPER.readValue(serializedString, getClass());
             BeanUtils.copyProperties(event, this);
         } catch (final Exception e) {
-            throw new IllegalStateException("Could not serialize " + getClass() + " : [" + serializedString + "]", e);
+            throw new IllegalStateException("Could not deserialize to event " + getClass().getName(), e);
         }
     }
 

--- a/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/EventPublisher.java
+++ b/cheddar/cheddar-events/src/main/java/com/clicktravel/cheddar/event/EventPublisher.java
@@ -33,7 +33,7 @@ public abstract class EventPublisher<E extends Event> {
     }
 
     public void publishEvent(final E event) {
-        logger.debug("Publishing event: [" + event.type() + "]");
+        logger.debug("Publishing event: " + event);
         final TypedMessage typedMessage = new SimpleMessage(event.type(), event.serialize());
         messagePublisher.publish(typedMessage);
     }

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sns/SnsTopicResource.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sns/SnsTopicResource.java
@@ -16,9 +16,6 @@
  */
 package com.clicktravel.infrastructure.messaging.aws.sns;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.policy.Policy;
 import com.amazonaws.services.sns.AmazonSNS;
@@ -35,7 +32,6 @@ public class SnsTopicResource {
 
     private static final String TOPIC_POLICY_ATTRIBUTE = "Policy";
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
     private final String topicName;
     private final String topicArn;
     private final AmazonSNS amazonSnsClient;
@@ -54,8 +50,6 @@ public class SnsTopicResource {
      */
     public void publish(final String subject, final String message) throws AmazonClientException {
         amazonSnsClient.publish(new PublishRequest().withTopicArn(topicArn).withSubject(subject).withMessage(message));
-        logger.debug("Successfully published message; subject:[" + subject + "] message:[" + message + "] snsName:["
-                + topicName + "]");
     }
 
     /**
@@ -74,8 +68,8 @@ public class SnsTopicResource {
      * @throws AmazonClientException
      */
     public void setPolicy(final Policy policy) throws AmazonClientException {
-        amazonSnsClient.setTopicAttributes(new SetTopicAttributesRequest(topicArn, TOPIC_POLICY_ATTRIBUTE, policy
-                .toJson()));
+        amazonSnsClient
+                .setTopicAttributes(new SetTopicAttributesRequest(topicArn, TOPIC_POLICY_ATTRIBUTE, policy.toJson()));
     }
 
     /**

--- a/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/exception/MessageHandlingException.java
+++ b/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/exception/MessageHandlingException.java
@@ -20,6 +20,14 @@ public class MessageHandlingException extends MessagingException {
 
     private static final long serialVersionUID = 5991755885193413206L;
 
+    public MessageHandlingException(final String message) {
+        super(message);
+    }
+
+    public MessageHandlingException(final Throwable cause) {
+        super(cause);
+    }
+
     public MessageHandlingException(final String message, final Throwable cause) {
         super(message, cause);
     }

--- a/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/ApplicationInstanceStartedEvent.java
+++ b/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/ApplicationInstanceStartedEvent.java
@@ -31,4 +31,11 @@ public class ApplicationInstanceStartedEvent extends AbstractPlatformManagementE
         this.applicationInstanceName = applicationInstanceName;
     }
 
+    @Override
+    public String toString() {
+        return "ApplicationInstanceStartedEvent [applicationInstanceName=" + applicationInstanceName
+                + ", getTargetApplicationName()=" + getTargetApplicationName() + ", getTargetApplicationVersion()="
+                + getTargetApplicationVersion() + "]";
+    }
+
 }

--- a/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/AppInstancesReadyToRunEvent.java
+++ b/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/AppInstancesReadyToRunEvent.java
@@ -26,4 +26,10 @@ import com.clicktravel.cheddar.system.event.AbstractSystemEvent;
  */
 public class AppInstancesReadyToRunEvent extends AbstractSystemEvent {
 
+    @Override
+    public String toString() {
+        return "AppInstancesReadyToRunEvent [getTargetApplicationName()=" + getTargetApplicationName()
+                + ", getTargetApplicationVersion()=" + getTargetApplicationVersion() + "]";
+    }
+
 }

--- a/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/NewAppInstancesBecomingHealthyEvent.java
+++ b/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/NewAppInstancesBecomingHealthyEvent.java
@@ -26,4 +26,10 @@ import com.clicktravel.cheddar.system.event.AbstractSystemEvent;
  */
 public class NewAppInstancesBecomingHealthyEvent extends AbstractSystemEvent {
 
+    @Override
+    public String toString() {
+        return "NewAppInstancesBecomingHealthyEvent [getTargetApplicationName()=" + getTargetApplicationName()
+                + ", getTargetApplicationVersion()=" + getTargetApplicationVersion() + "]";
+    }
+
 }

--- a/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/NewAppInstancesDeployedEvent.java
+++ b/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/NewAppInstancesDeployedEvent.java
@@ -26,4 +26,10 @@ import com.clicktravel.cheddar.system.event.AbstractSystemEvent;
  */
 public class NewAppInstancesDeployedEvent extends AbstractSystemEvent {
 
+    @Override
+    public String toString() {
+        return "NewAppInstancesDeployedEvent [getTargetApplicationName()=" + getTargetApplicationName()
+                + ", getTargetApplicationVersion()=" + getTargetApplicationVersion() + "]";
+    }
+
 }

--- a/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/OldAppInstancesEventProcessingHaltedEvent.java
+++ b/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/OldAppInstancesEventProcessingHaltedEvent.java
@@ -26,4 +26,10 @@ import com.clicktravel.cheddar.system.event.AbstractSystemEvent;
  */
 public class OldAppInstancesEventProcessingHaltedEvent extends AbstractSystemEvent {
 
+    @Override
+    public String toString() {
+        return "OldAppInstancesEventProcessingHaltedEvent [getTargetApplicationName()=" + getTargetApplicationName()
+                + ", getTargetApplicationVersion()=" + getTargetApplicationVersion() + "]";
+    }
+
 }

--- a/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/OldAppInstancesRestRequestsDrainedEvent.java
+++ b/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/OldAppInstancesRestRequestsDrainedEvent.java
@@ -26,4 +26,10 @@ import com.clicktravel.cheddar.system.event.AbstractSystemEvent;
  */
 public class OldAppInstancesRestRequestsDrainedEvent extends AbstractSystemEvent {
 
+    @Override
+    public String toString() {
+        return "OldAppInstancesRestRequestsDrainedEvent [getTargetApplicationName()=" + getTargetApplicationName()
+                + ", getTargetApplicationVersion()=" + getTargetApplicationVersion() + "]";
+    }
+
 }

--- a/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/OldAppInstancesTerminatedEvent.java
+++ b/cheddar/cheddar-system-events/src/main/java/com/clicktravel/cheddar/system/event/application/lifecycle/OldAppInstancesTerminatedEvent.java
@@ -25,4 +25,10 @@ import com.clicktravel.cheddar.system.event.AbstractSystemEvent;
  */
 public class OldAppInstancesTerminatedEvent extends AbstractSystemEvent {
 
+    @Override
+    public String toString() {
+        return "OldAppInstancesTerminatedEvent [getTargetApplicationName()=" + getTargetApplicationName()
+                + ", getTargetApplicationVersion()=" + getTargetApplicationVersion() + "]";
+    }
+
 }


### PR DESCRIPTION
Events may contain confidential information which should not be casually logged. This commit changes logging of Events to use its toString() method, rather than logging the bodies of message used to publish them. This allows finer grained control of the logged content of published and handled events.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>