### PR TITLE
[FC-107] S3ObjectInputStream should be closed after use

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/s3/S3FileStore.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/s3/S3FileStore.java
@@ -94,7 +94,7 @@ public class S3FileStore implements InternetFileStore {
             }
             throw e;
         } catch (final IOException e1) {
-            logger.error("Error occured while closing S3Object Stream");
+            logger.warn("Error closing S3Object", e1);
         }
         return fileItem;
     }

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/s3/S3FileStore.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/persistence/aws/s3/S3FileStore.java
@@ -75,33 +75,41 @@ public class S3FileStore implements InternetFileStore {
         checkInitialization();
         final GetObjectRequest getObjectRequest = new GetObjectRequest(bucketNameForFilePath(filePath),
                 filePath.filename());
-        try {
-            final S3Object s3Object = amazonS3Client.getObject(getObjectRequest);
+        FileItem fileItem = null;
+        try (final S3Object s3Object = amazonS3Client.getObject(getObjectRequest)) {
+
             final Map<String, String> userMetaData = getUserMetaData(s3Object);
             final String filename = userMetaData.get(USER_METADATA_FILENAME);
-            final String lastUpdatedTimeStr = userMetaData.get(USER_METADATA_LAST_UPDATED_TIME);
-            DateTime lastUpdatedTime = null;
-            if (lastUpdatedTimeStr != null) {
-                try {
-                    lastUpdatedTime = formatter.parseDateTime(lastUpdatedTimeStr);
-                } catch (final Exception e) {
-                    logger.warn(e.getMessage(), e);
-                }
-            }
+            final DateTime lastUpdatedTime = getLastUpdatedTime(userMetaData);
             try {
 
-                final FileItem fileItem = new FileItem(filename, s3Object.getObjectContent(), lastUpdatedTime);
-                return fileItem;
+                fileItem = new FileItem(filename, s3Object.getObjectContent(), lastUpdatedTime);
             } catch (final IOException e) {
                 throw new IllegalStateException(e);
             }
         } catch (final AmazonS3Exception e) {
             if (missingItemErrorCodes.contains(e.getErrorCode())) {
-                throw new NonExistentItemException("Item does not exist" + filePath.directory() + "->"
-                        + filePath.filename());
+                throw new NonExistentItemException(
+                        "Item does not exist" + filePath.directory() + "->" + filePath.filename());
             }
             throw e;
+        } catch (final IOException e1) {
+            logger.error("Error occured while closing S3Object Stream");
         }
+        return fileItem;
+    }
+
+    private DateTime getLastUpdatedTime(final Map<String, String> userMetaData) {
+        final String lastUpdatedTimeStr = userMetaData.get(USER_METADATA_LAST_UPDATED_TIME);
+        DateTime lastUpdatedTime = null;
+        if (lastUpdatedTimeStr != null) {
+            try {
+                lastUpdatedTime = formatter.parseDateTime(lastUpdatedTimeStr);
+            } catch (final Exception e) {
+                logger.warn(e.getMessage(), e);
+            }
+        }
+        return lastUpdatedTime;
     }
 
     /**
@@ -153,8 +161,8 @@ public class S3FileStore implements InternetFileStore {
             amazonS3Client.deleteObject(bucketNameForFilePath(filePath), filePath.filename());
         } catch (final AmazonS3Exception e) {
             if (missingItemErrorCodes.contains(e.getErrorCode())) {
-                throw new NonExistentItemException("Item does not exist" + filePath.directory() + "->"
-                        + filePath.filename());
+                throw new NonExistentItemException(
+                        "Item does not exist" + filePath.directory() + "->" + filePath.filename());
             }
             throw e;
         }
@@ -180,8 +188,8 @@ public class S3FileStore implements InternetFileStore {
 
     @Override
     public URL publicUrlForFilePath(final FilePath filePath) throws NonExistentItemException {
-        return amazonS3Client.generatePresignedUrl(bucketNameForFilePath(filePath), filePath.filename(), DateTime.now()
-                .plusHours(1).toDate(), HttpMethod.GET);
+        return amazonS3Client.generatePresignedUrl(bucketNameForFilePath(filePath), filePath.filename(),
+                DateTime.now().plusHours(1).toDate(), HttpMethod.GET);
     }
 
     @Override
@@ -201,8 +209,9 @@ public class S3FileStore implements InternetFileStore {
             return filePathList;
 
         } catch (final AmazonS3Exception e) {
-            throw new PersistenceResourceFailureException("An error occurred obtaining a listing of directory -> "
-                    + directory + " with prefix -> " + prefix, e);
+            throw new PersistenceResourceFailureException(
+                    "An error occurred obtaining a listing of directory -> " + directory + " with prefix -> " + prefix,
+                    e);
         }
     }
 }

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/s3/S3FileStoreTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/s3/S3FileStoreTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -134,16 +135,16 @@ public class S3FileStoreTest {
         final ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor = ArgumentCaptor
                 .forClass(PutObjectRequest.class);
         verify(mockAmazonS3Client).putObject(putObjectRequestArgumentCaptor.capture());
-        assertEquals(bucketSchema + "-" + filePath.directory(), putObjectRequestArgumentCaptor.getValue()
-                .getBucketName());
+        assertEquals(bucketSchema + "-" + filePath.directory(),
+                putObjectRequestArgumentCaptor.getValue().getBucketName());
         assertEquals(filePath.filename(), putObjectRequestArgumentCaptor.getValue().getKey());
         final InputStream inputStream = putObjectRequestArgumentCaptor.getValue().getInputStream();
         assertEquals(fileContent, inputStreamToString(inputStream));
         assertEquals(2, putObjectRequestArgumentCaptor.getValue().getMetadata().getUserMetadata().size());
-        assertEquals(fileItem.filename(), putObjectRequestArgumentCaptor.getValue().getMetadata().getUserMetadata()
-                .get("filename"));
-        assertEquals(formatter.print(fileItem.lastUpdatedTime()), putObjectRequestArgumentCaptor.getValue()
-                .getMetadata().getUserMetadata().get("last-updated-time"));
+        assertEquals(fileItem.filename(),
+                putObjectRequestArgumentCaptor.getValue().getMetadata().getUserMetadata().get("filename"));
+        assertEquals(formatter.print(fileItem.lastUpdatedTime()),
+                putObjectRequestArgumentCaptor.getValue().getMetadata().getUserMetadata().get("last-updated-time"));
     }
 
     @SuppressWarnings("resource")
@@ -179,8 +180,42 @@ public class S3FileStoreTest {
         final ArgumentCaptor<GetObjectRequest> getObjectRequestArgumentCaptor = ArgumentCaptor
                 .forClass(GetObjectRequest.class);
         verify(mockAmazonS3Client).getObject(getObjectRequestArgumentCaptor.capture());
-        assertEquals(bucketSchema + "-" + filePath.directory(), getObjectRequestArgumentCaptor.getValue()
-                .getBucketName());
+        assertEquals(bucketSchema + "-" + filePath.directory(),
+                getObjectRequestArgumentCaptor.getValue().getBucketName());
+        assertEquals(filePath.filename(), getObjectRequestArgumentCaptor.getValue().getKey());
+        assertEquals(filename, fileItem.filename());
+        assertEquals(expectedLastUpdatedTime, fileItem.lastUpdatedTime());
+    }
+
+    @Test
+    public void shouldReadFile_withCloseIOException() throws Exception {
+        // Given
+        final String filename = randomString(10);
+        final DateTime lastUpdatedTime = randomDateTime();
+        final DateTime expectedLastUpdatedTime = lastUpdatedTime.withZone(DateTimeZone.UTC).withMillisOfSecond(0);
+        final S3FileStore s3FileStore = new S3FileStore(bucketSchema);
+        s3FileStore.initialize(mockAmazonS3Client);
+        final S3Object mockS3Object = mock(S3Object.class);
+        final ObjectMetadata mockObjectMetadata = mock(ObjectMetadata.class);
+        final Map<String, String> userMetadata = new HashMap<>();
+        userMetadata.put("filename", filename);
+        userMetadata.put("last-updated-time", formatter.print(lastUpdatedTime));
+        when(mockAmazonS3Client.getObject(any(GetObjectRequest.class))).thenReturn(mockS3Object);
+        final S3ObjectInputStream mockInputStream = mock(S3ObjectInputStream.class);
+        when(mockS3Object.getObjectContent()).thenReturn(mockInputStream);
+        when(mockS3Object.getObjectMetadata()).thenReturn(mockObjectMetadata);
+        when(mockObjectMetadata.getUserMetadata()).thenReturn(userMetadata);
+        when(mockInputStream.read(any(byte[].class))).thenReturn(-1);
+        doThrow(IOException.class).when(mockS3Object).close();
+        // When
+        final FileItem fileItem = s3FileStore.read(filePath);
+
+        // Then
+        final ArgumentCaptor<GetObjectRequest> getObjectRequestArgumentCaptor = ArgumentCaptor
+                .forClass(GetObjectRequest.class);
+        verify(mockAmazonS3Client).getObject(getObjectRequestArgumentCaptor.capture());
+        assertEquals(bucketSchema + "-" + filePath.directory(),
+                getObjectRequestArgumentCaptor.getValue().getBucketName());
         assertEquals(filePath.filename(), getObjectRequestArgumentCaptor.getValue().getKey());
         assertEquals(filename, fileItem.filename());
         assertEquals(expectedLastUpdatedTime, fileItem.lastUpdatedTime());


### PR DESCRIPTION
After retriving an S3Object, we need to close this input stream as soon as possible, because the object contents aren't buffered in memory and stream directly from Amazon S3. Further, failure to close this stream can cause the request pool to become blocked.