### PR TITLE
Improper persistence exception handling

### DIFF
--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/CloudSearchEngineTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/persistence/aws/cloudsearch/CloudSearchEngineTest.java
@@ -868,7 +868,7 @@ public class CloudSearchEngineTest {
 
     private Collection<StubDocument> randomCollectionOfStubDocuments() {
         final Collection<StubDocument> documents = new ArrayList<>();
-        final int numberOfDocuments = Randoms.randomInt(10);
+        final int numberOfDocuments = Randoms.randomIntInRange(1, 10);
         for (int i = 0; i < numberOfDocuments; i++) {
             documents.add(randomStubDocument());
         }

--- a/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/exception/handler/PersistenceExceptionHandler.java
+++ b/cheddar/cheddar-persistence/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/exception/handler/PersistenceExceptionHandler.java
@@ -22,4 +22,8 @@ public interface PersistenceExceptionHandler<T extends PersistenceException> {
 
     abstract void handle(T exception);
 
+    default Class<? extends PersistenceException> getExceptionClass() {
+        return PersistenceException.class;
+    }
+
 }

--- a/cheddar/cheddar-tx/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/tx/DatabaseAction.java
+++ b/cheddar/cheddar-tx/src/main/java/com/clicktravel/cheddar/infrastructure/persistence/database/tx/DatabaseAction.java
@@ -64,8 +64,8 @@ public abstract class DatabaseAction<T> {
             final PersistenceException persistenceException) throws NoSuchMethodException {
         for (final Method method : persistenceExceptionHandler.getClass().getMethods()) {
             final Class<?>[] parameterTypes = method.getParameterTypes();
-            if (method.getName().equals("handle") && parameterTypes.length == 1
-                    && parameterTypes[0].isAssignableFrom(persistenceException.getClass())) {
+            if (method.getName().equals("handle") && parameterTypes.length == 1 && persistenceExceptionHandler
+                    .getExceptionClass().isAssignableFrom(persistenceException.getClass())) {
                 return method;
             }
         }


### PR DESCRIPTION
@clicktravel-steffan I think we can solve the problem of not matching the right persistence exception handler by adding a new method in `PersistenceExceptionHandler`. So that it won't contain braking changes, could be done in two steps:
1. Create the method `getExceptionClass` as `default` and client implementation so that the right exception class will be returned (ex. `ItemConstraintViolationException`)
2. Delete the default implementation of the method `getExceptionHandler` method