### PR TITLE
Match version of Jackson used in transitive dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 springVersion=4.1.1.RELEASE
 awsJavaSdkVersion=1.11.6
-jacksonVersion=2.6.3
+jacksonVersion=2.6.6
 jerseyVersion=2.22.1
 jodaTimeVersion=2.8.2
 slf4jVersion=1.7.5


### PR DESCRIPTION
The version of Jackson used in Cheddar's combined dependencies is 2.6.6, not 2.6.3. This is due to a transitive dependency of cheddar-integration-aws.

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>