### PR TITLE
Fix for forming the file download URL based on the item's filename.

### DIFF
--- a/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/filestore/InMemoryInternetFileStore.java
+++ b/cheddar/cheddar-integration-mocks/src/main/java/com/clicktravel/infrastructure/persistence/inmemory/filestore/InMemoryInternetFileStore.java
@@ -20,6 +20,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import com.clicktravel.cheddar.infrastructure.persistence.database.exception.NonExistentItemException;
+import com.clicktravel.cheddar.infrastructure.persistence.filestore.FileItem;
 import com.clicktravel.cheddar.infrastructure.persistence.filestore.FilePath;
 import com.clicktravel.cheddar.infrastructure.persistence.filestore.InternetFileStore;
 
@@ -28,8 +29,8 @@ public class InMemoryInternetFileStore extends InMemoryFileStore implements Inte
     @Override
     public URL publicUrlForFilePath(final FilePath filePath) throws NonExistentItemException {
         try {
-            read(filePath);
-            return new URL("http://" + filePath.directory() + "localhost/" + filePath.filename());
+            final FileItem fileItem = read(filePath);
+            return new URL("http://" + filePath.directory() + "localhost/" + fileItem.filename());
         } catch (final MalformedURLException e) {
             throw new IllegalStateException("Invalid file path. directory:[" + filePath.directory() + "], filename:["
                     + filePath.filename() + "]");

--- a/cheddar/cheddar-integration-mocks/src/test/java/com/clicktravel/infrastructure/persistence/inmemory/filestore/InMemoryInternetFileStoreTest.java
+++ b/cheddar/cheddar-integration-mocks/src/test/java/com/clicktravel/infrastructure/persistence/inmemory/filestore/InMemoryInternetFileStoreTest.java
@@ -45,7 +45,8 @@ public class InMemoryInternetFileStoreTest {
         final URL publicUrl = fileStore.publicUrlForFilePath(filePath);
 
         // Then
-        assertThat(publicUrl, is(new URL("http://" + filePath.directory() + "localhost/" + filePath.filename())));
+        assertThat(publicUrl,
+                is(new URL("http://" + filePath.directory() + "localhost/" + expectedFileItem.filename())));
     }
 
     @Test


### PR DESCRIPTION
This change is needed to model the behaviour existent in the
corresponding S3 implementation.