### PR TITLE
Change retry behaviour for deleting SQS messages

### DIFF
--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsBasicMessageQueue.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsBasicMessageQueue.java
@@ -33,7 +33,7 @@ public class SqsBasicMessageQueue extends SqsMessageQueue<BasicMessage> {
 
     @Override
     protected BasicMessage toMessage(final Message sqsMessage) {
-        return new SimpleBasicMessage(sqsMessage.getBody(), sqsMessage.getReceiptHandle());
+        return new SimpleBasicMessage(sqsMessage.getBody(), sqsMessage.getMessageId(), sqsMessage.getReceiptHandle());
     }
 
 }

--- a/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsTypedMessageQueue.java
+++ b/cheddar/cheddar-integration-aws/src/main/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsTypedMessageQueue.java
@@ -50,15 +50,16 @@ public class SqsTypedMessageQueue extends SqsMessageQueue<TypedMessage> {
     @Override
     protected TypedMessage toMessage(final com.amazonaws.services.sqs.model.Message sqsMessage) {
         final String receiptHandle = sqsMessage.getReceiptHandle();
+        final String messageId = sqsMessage.getMessageId();
         try {
             final ObjectMapper mapper = new ObjectMapper();
             final JsonNode jsonNode = mapper.readTree(sqsMessage.getBody());
             final String messageType = jsonNode.get("Subject").textValue();
             final String messagePayload = jsonNode.get("Message").textValue();
-            return new SimpleMessage(messageType, messagePayload, receiptHandle);
+            return new SimpleMessage(messageType, messagePayload, messageId, receiptHandle);
         } catch (final Exception e) {
-            return new InvalidTypedMessage(receiptHandle, new MessageParseException(
-                    "Could not parse message from SQS message: " + sqsMessage.getBody()));
+            return new InvalidTypedMessage(messageId, receiptHandle,
+                    new MessageParseException("Could not parse message from SQS message: " + sqsMessage.getBody()));
         }
     }
 

--- a/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsBasicMessageQueueTest.java
+++ b/cheddar/cheddar-integration-aws/src/test/java/com/clicktravel/infrastructure/messaging/aws/sqs/SqsBasicMessageQueueTest.java
@@ -16,6 +16,7 @@
  */
 package com.clicktravel.infrastructure.messaging.aws.sqs;
 
+import static com.clicktravel.common.random.Randoms.randomId;
 import static com.clicktravel.common.random.Randoms.randomString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -62,14 +63,19 @@ public class SqsBasicMessageQueueTest {
         final List<com.amazonaws.services.sqs.model.Message> mockSqsMessages = new LinkedList<>();
         final List<String> bodies = new LinkedList<>();
         final List<String> receiptHandles = new LinkedList<>();
+        final List<String> messageIds = new LinkedList<>();
         for (int i = 0; i < 3; i++) {
             final String body = randomString();
-            final String receiptHandle = randomString();
-            final com.amazonaws.services.sqs.model.Message mockSqsMessage = mock(com.amazonaws.services.sqs.model.Message.class);
+            final String messageId = randomId();
+            final String receiptHandle = randomId();
+            final com.amazonaws.services.sqs.model.Message mockSqsMessage = mock(
+                    com.amazonaws.services.sqs.model.Message.class);
+            when(mockSqsMessage.getMessageId()).thenReturn(messageId);
             when(mockSqsMessage.getReceiptHandle()).thenReturn(receiptHandle);
             when(mockSqsMessage.getBody()).thenReturn(body);
             mockSqsMessages.add(mockSqsMessage);
             bodies.add(body);
+            messageIds.add(messageId);
             receiptHandles.add(receiptHandle);
         }
         when(mockSqsQueueResource.receiveMessages()).thenReturn(mockSqsMessages);
@@ -83,6 +89,7 @@ public class SqsBasicMessageQueueTest {
         for (int i = 0; i < 3; i++) {
             final BasicMessage receivedMessage = receivedMessages.get(i);
             assertEquals(bodies.get(i), receivedMessage.getBody());
+            assertEquals(messageIds.get(i), receivedMessage.getMessageId());
             assertEquals(receiptHandles.get(i), receivedMessage.getReceiptHandle());
         }
     }

--- a/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/AbstractMessage.java
+++ b/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/AbstractMessage.java
@@ -18,10 +18,17 @@ package com.clicktravel.cheddar.infrastructure.messaging;
 
 public abstract class AbstractMessage implements Message {
 
+    private final String messageId;
     private final String receiptHandle;
 
-    public AbstractMessage(final String receiptHandle) {
+    public AbstractMessage(final String messageId, final String receiptHandle) {
+        this.messageId = messageId;
         this.receiptHandle = receiptHandle;
+    }
+
+    @Override
+    public String getMessageId() {
+        return messageId;
     }
 
     @Override

--- a/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidBasicMessage.java
+++ b/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidBasicMessage.java
@@ -20,8 +20,9 @@ import com.clicktravel.cheddar.infrastructure.messaging.exception.MessageParseEx
 
 public class InvalidBasicMessage extends InvalidMessage implements BasicMessage {
 
-    public InvalidBasicMessage(final String receiptHandle, final MessageParseException messageParseException) {
-        super(receiptHandle, messageParseException);
+    public InvalidBasicMessage(final String messageId, final String receiptHandle,
+            final MessageParseException messageParseException) {
+        super(messageId, receiptHandle, messageParseException);
     }
 
     @Override

--- a/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidMessage.java
+++ b/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidMessage.java
@@ -22,8 +22,9 @@ public abstract class InvalidMessage extends AbstractMessage {
 
     private final MessageParseException messageParseException;
 
-    public InvalidMessage(final String receiptHandle, final MessageParseException messageParseException) {
-        super(receiptHandle);
+    public InvalidMessage(final String messageId, final String receiptHandle,
+            final MessageParseException messageParseException) {
+        super(messageId, receiptHandle);
         this.messageParseException = messageParseException;
     }
 

--- a/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidTypedMessage.java
+++ b/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidTypedMessage.java
@@ -20,8 +20,9 @@ import com.clicktravel.cheddar.infrastructure.messaging.exception.MessageParseEx
 
 public class InvalidTypedMessage extends InvalidMessage implements TypedMessage {
 
-    public InvalidTypedMessage(final String receiptHandle, final MessageParseException messageParseException) {
-        super(receiptHandle, messageParseException);
+    public InvalidTypedMessage(final String messageId, final String receiptHandle,
+            final MessageParseException messageParseException) {
+        super(messageId, receiptHandle, messageParseException);
     }
 
     @Override

--- a/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/Message.java
+++ b/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/Message.java
@@ -28,4 +28,9 @@ public interface Message {
      *         used to delete this message from the queue.
      */
     String getReceiptHandle();
+
+    /**
+     * @return Unique identifier for the message
+     */
+    String getMessageId();
 }

--- a/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/SimpleBasicMessage.java
+++ b/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/SimpleBasicMessage.java
@@ -20,13 +20,13 @@ public class SimpleBasicMessage extends AbstractMessage implements BasicMessage 
 
     private final String body;
 
-    public SimpleBasicMessage(final String body, final String receiptHandle) {
-        super(receiptHandle);
+    public SimpleBasicMessage(final String body, final String messageId, final String receiptHandle) {
+        super(messageId, receiptHandle);
         this.body = body;
     }
 
     public SimpleBasicMessage(final String body) {
-        this(body, null);
+        this(body, null, null);
     }
 
     @Override

--- a/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/SimpleMessage.java
+++ b/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/SimpleMessage.java
@@ -21,14 +21,14 @@ public class SimpleMessage extends AbstractMessage implements TypedMessage {
     private final String type;
     private final String payload;
 
-    public SimpleMessage(final String type, final String payload, final String receiptHandle) {
-        super(receiptHandle);
+    public SimpleMessage(final String type, final String payload, final String messageId, final String receiptHandle) {
+        super(messageId, receiptHandle);
         this.type = type;
         this.payload = payload;
     }
 
     public SimpleMessage(final String type, final String payload) {
-        this(type, payload, null);
+        this(type, payload, null, null);
     }
 
     @Override

--- a/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/pooled/listener/PooledMessageListener.java
+++ b/cheddar/cheddar-messaging/src/main/java/com/clicktravel/cheddar/infrastructure/messaging/pooled/listener/PooledMessageListener.java
@@ -83,12 +83,12 @@ public abstract class PooledMessageListener<T extends Message> implements Messag
     /**
      * Maximum number of attempts to delete message from queue
      */
-    private static final int MAX_DELETE_MESSAGE_ATTEMPTS = 3;
+    private static final int MAX_DELETE_MESSAGE_ATTEMPTS = 5;
 
     /**
      * Time (in milliseconds) to pause when delete message request returns an error
      */
-    private static final long DELETE_MESSAGE_ERROR_PAUSE_MILLIS = 500;
+    private static final long DELETE_MESSAGE_ERROR_PAUSE_MILLIS = 1500;
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final MessageQueue<T> messageQueue;
@@ -209,11 +209,13 @@ public abstract class PooledMessageListener<T extends Message> implements Messag
                 messageQueue.delete(message);
                 return;
             } catch (final MessageDeleteException e) {
-                logger.warn("Failed attempt to delete message from queue:[" + queueName() + "]", e);
+                logger.warn("Failed attempt to delete message with id [" + message.getMessageId() + "] from queue ["
+                        + queueName() + "]", e);
                 Thread.sleep(DELETE_MESSAGE_ERROR_PAUSE_MILLIS);
             }
         }
-        logger.error("Failed all attempts to delete message from queue:[" + queueName() + "]");
+        logger.error("Failed all attempts to delete message with id [" + message.getMessageId() + "] from queue ["
+                + queueName() + "]");
     }
 
     private void applyRateLimiter() {

--- a/cheddar/cheddar-messaging/src/test/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidBasicMessageTest.java
+++ b/cheddar/cheddar-messaging/src/test/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidBasicMessageTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.infrastructure.messaging;
+
+import static com.clicktravel.common.random.Randoms.randomId;
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.clicktravel.cheddar.infrastructure.messaging.exception.MessageParseException;
+
+public class InvalidBasicMessageTest {
+
+    private String messageId;
+    private String receiptHandle;
+    private MessageParseException messageParseException;
+    private InvalidBasicMessage message;
+
+    @Before
+    public void setUp() {
+        messageId = randomId();
+        receiptHandle = randomId();
+        messageParseException = new MessageParseException(randomString());
+        message = new InvalidBasicMessage(messageId, receiptHandle, messageParseException);
+    }
+
+    @Test
+    public void shouldReturnMessageId() {
+        // When
+        final String result = message.getMessageId();
+
+        // Then
+        assertEquals(messageId, result);
+    }
+
+    @Test
+    public void shouldReturnReceiptHandle() {
+        // When
+        final String result = message.getReceiptHandle();
+
+        // Then
+        assertEquals(receiptHandle, result);
+    }
+
+    @Test
+    public void shouldNotReturnBody() {
+        // When
+        MessageParseException thrownException = null;
+        try {
+            message.getBody();
+        } catch (final MessageParseException e) {
+            thrownException = e;
+        }
+
+        // Then
+        assertSame(messageParseException, thrownException);
+    }
+
+}

--- a/cheddar/cheddar-messaging/src/test/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidTypedMessageTest.java
+++ b/cheddar/cheddar-messaging/src/test/java/com/clicktravel/cheddar/infrastructure/messaging/InvalidTypedMessageTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.infrastructure.messaging;
+
+import static com.clicktravel.common.random.Randoms.randomId;
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.clicktravel.cheddar.infrastructure.messaging.exception.MessageParseException;
+
+public class InvalidTypedMessageTest {
+
+    private String messageId;
+    private String receiptHandle;
+    private MessageParseException messageParseException;
+    private InvalidTypedMessage message;
+
+    @Before
+    public void setUp() {
+        messageId = randomId();
+        receiptHandle = randomId();
+        messageParseException = new MessageParseException(randomString());
+        message = new InvalidTypedMessage(messageId, receiptHandle, messageParseException);
+    }
+
+    @Test
+    public void shouldReturnMessageId() {
+        // When
+        final String result = message.getMessageId();
+
+        // Then
+        assertEquals(messageId, result);
+    }
+
+    @Test
+    public void shouldReturnReceiptHandle() {
+        // When
+        final String result = message.getReceiptHandle();
+
+        // Then
+        assertEquals(receiptHandle, result);
+    }
+
+    @Test
+    public void shouldNotReturnType() {
+        // When
+        MessageParseException thrownException = null;
+        try {
+            message.getType();
+        } catch (final MessageParseException e) {
+            thrownException = e;
+        }
+
+        // Then
+        assertSame(messageParseException, thrownException);
+    }
+
+    @Test
+    public void shouldNotReturnPayload() {
+        // When
+        MessageParseException thrownException = null;
+        try {
+            message.getPayload();
+        } catch (final MessageParseException e) {
+            thrownException = e;
+        }
+
+        // Then
+        assertSame(messageParseException, thrownException);
+    }
+}

--- a/cheddar/cheddar-messaging/src/test/java/com/clicktravel/cheddar/infrastructure/messaging/SimpleBasicMessageTest.java
+++ b/cheddar/cheddar-messaging/src/test/java/com/clicktravel/cheddar/infrastructure/messaging/SimpleBasicMessageTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.infrastructure.messaging;
+
+import static com.clicktravel.common.random.Randoms.randomId;
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class SimpleBasicMessageTest {
+
+    @Test
+    public void shouldReturnMessageId() {
+        // Given
+        final String body = randomString();
+        final String messageId = randomId();
+        final String receiptHandle = randomId();
+        final SimpleBasicMessage message = new SimpleBasicMessage(body, messageId, receiptHandle);
+
+        // When
+        final String result = message.getMessageId();
+
+        // Then
+        assertEquals(messageId, result);
+    }
+
+    @Test
+    public void shouldReturnReceiptHandle() {
+        // Given
+        final String body = randomString();
+        final String messageId = randomId();
+        final String receiptHandle = randomId();
+        final SimpleBasicMessage message = new SimpleBasicMessage(body, messageId, receiptHandle);
+
+        // When
+        final String result = message.getReceiptHandle();
+
+        // Then
+        assertEquals(receiptHandle, result);
+    }
+
+    @Test
+    public void shouldReturnBody() {
+        // Given
+        final String body = randomString();
+        final String messageId = randomId();
+        final String receiptHandle = randomId();
+        final SimpleBasicMessage message = new SimpleBasicMessage(body, messageId, receiptHandle);
+
+        // When
+        final String result = message.getBody();
+
+        // Then
+        assertEquals(body, result);
+    }
+
+    @Test
+    public void shouldConstruct_withBody() {
+        // Given
+        final String body = randomString();
+
+        // When
+        final SimpleBasicMessage message = new SimpleBasicMessage(body);
+
+        // Then
+        assertNull(message.getMessageId());
+        assertNull(message.getReceiptHandle());
+        assertEquals(body, message.getBody());
+    }
+}

--- a/cheddar/cheddar-messaging/src/test/java/com/clicktravel/cheddar/infrastructure/messaging/SimpleMessageTest.java
+++ b/cheddar/cheddar-messaging/src/test/java/com/clicktravel/cheddar/infrastructure/messaging/SimpleMessageTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014 Click Travel Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.clicktravel.cheddar.infrastructure.messaging;
+
+import static com.clicktravel.common.random.Randoms.randomId;
+import static com.clicktravel.common.random.Randoms.randomString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class SimpleMessageTest {
+
+    @Test
+    public void shouldReturnType() {
+        // Given
+        final String type = randomString();
+        final String payload = randomString();
+        final String messageId = randomId();
+        final String receiptHandle = randomId();
+        final SimpleMessage message = new SimpleMessage(type, payload, messageId, receiptHandle);
+
+        // When
+        final String result = message.getType();
+
+        // Then
+        assertEquals(type, result);
+    }
+
+    @Test
+    public void shouldReturnPayload() {
+        // Given
+        final String type = randomString();
+        final String payload = randomString();
+        final String messageId = randomId();
+        final String receiptHandle = randomId();
+        final SimpleMessage message = new SimpleMessage(type, payload, messageId, receiptHandle);
+
+        // When
+        final String result = message.getPayload();
+
+        // Then
+        assertEquals(payload, result);
+    }
+
+    @Test
+    public void shouldReturnMessageId() {
+        // Given
+        final String type = randomString();
+        final String payload = randomString();
+        final String messageId = randomId();
+        final String receiptHandle = randomId();
+        final SimpleMessage message = new SimpleMessage(type, payload, messageId, receiptHandle);
+
+        // When
+        final String result = message.getMessageId();
+
+        // Then
+        assertEquals(messageId, result);
+    }
+
+    @Test
+    public void shouldReturnReceiptHandle() {
+        // Given
+        final String type = randomString();
+        final String payload = randomString();
+        final String messageId = randomId();
+        final String receiptHandle = randomId();
+        final SimpleMessage message = new SimpleMessage(type, payload, messageId, receiptHandle);
+
+        // When
+        final String result = message.getReceiptHandle();
+
+        // Then
+        assertEquals(receiptHandle, result);
+    }
+
+    @Test
+    public void shouldConstruct_withTypeAndPayload() {
+        // Given
+        final String type = randomString();
+        final String payload = randomString();
+
+        // When
+        final SimpleMessage message = new SimpleMessage(type, payload);
+
+        // Then
+        assertEquals(type, message.getType());
+        assertEquals(payload, message.getPayload());
+        assertNull(message.getMessageId());
+        assertNull(message.getReceiptHandle());
+    }
+}


### PR DESCRIPTION
- Attempt to delete SQS message up to 5 times, with requests 1500ms apart
- Add message ID to logged information when delete attempt fails

Signed-off-by: Steffan Westcott <steffan.westcott@clicktravel.com>